### PR TITLE
Rfoxkendo/issue101/120

### DIFF
--- a/main/utilities/manager/userguide.xml
+++ b/main/utilities/manager/userguide.xml
@@ -1399,7 +1399,7 @@
      <section id='sec.mgr.runcontrol'>
         <title id='sec.mgr.runcontrol.title'>The Run Control Panel</title>
         <para>
-          The run control panel application, <command>mg_RunControl</command>
+          The run control panel application, <command>rdo_RunControl</command>
           provides a control panel that can manage state transitions, run
           metadata, event logging and can monitor trigger statistics from
           compatible readout programs.

--- a/main/utilities/readoutREST/Makefile.am
+++ b/main/utilities/readoutREST/Makefile.am
@@ -1,5 +1,5 @@
 program_scripts=rdo_control.tcl rdo_titleFromKv.tcl rdo_runFromKv.tcl \
-	rdo_RunControl.tcl
+	rdo_RunControl.tcl rdo_stamp.tcl
 server_scripts=ReadoutControl.tcl ReadoutStatus.tcl ReadoutParameters.tcl
 library_scripts=ReadoutREST.tcl ReadoutRESTClient.tcl ReadoutRESTUI.tcl \
 	rdo_utils.tcl

--- a/main/utilities/readoutREST/Makefile.am
+++ b/main/utilities/readoutREST/Makefile.am
@@ -2,7 +2,7 @@ program_scripts=rdo_control.tcl rdo_titleFromKv.tcl rdo_runFromKv.tcl \
 	rdo_RunControl.tcl rdo_stamp.tcl
 server_scripts=ReadoutControl.tcl ReadoutStatus.tcl ReadoutParameters.tcl
 library_scripts=ReadoutREST.tcl ReadoutRESTClient.tcl ReadoutRESTUI.tcl \
-	rdo_utils.tcl
+	rdo_utils.tcl rdo_elapsedTime.tcl
 share_scripts=rest_init_script.tcl
 
 test_scripts=

--- a/main/utilities/readoutREST/rdo_RunControl.tcl
+++ b/main/utilities/readoutREST/rdo_RunControl.tcl
@@ -258,7 +258,7 @@ snit::widgetadaptor ReadoutManagerControl {
     option -readoutstate -configuremethod _cfgRdoState 
     option -bootcommand [list]
     option -shutdowncommand [list]
-    option -elapsed "*Unknown*"
+    option -elapsed -default "*Unknown*"
     
     # Options delegated ton the parameters widget:
     
@@ -288,20 +288,21 @@ snit::widgetadaptor ReadoutManagerControl {
         
         ttk::labelframe $win.manager -borderwidth 3 -relief groove -text "Manager"
         ttk::label $win.manager.statelabel -text "State: "
-        ttk::label $win.manager.state -textvariable [myvar options(-state)]
+        ttk::label $win.manager.state -textvariable [myvar options(-state) ]
         ttk::button $win.manager.boot -text Boot -command [mymethod _dispatchBoot] \
             -state disabled
         ttk::button $win.manager.shutdown -text Shutdown \
             -command [mymethod _dispatchShutdown] \
             -state disabled
-	ttk::label $win.elapsed -text -textvariable [myvar options(-elapsed)
+	ttk::label $win.lelapsed -text {Elapsed run time: }
+	ttk::label $win.elapsed  -textvariable [myvar options(-elapsed)]
         
         grid $win.manager.statelabel $win.manager.state -sticky w
         grid $win.manager.boot $win.manager.shutdown    -sticky w -padx 3
         
         grid $parameters -columnspan 3
         grid $win.manager $control
-	grid $win.elapsed 
+	grid $win.lelapsed $win.elapsed 
         
         $self configurelist $args
         
@@ -676,13 +677,13 @@ snit::type SystemStateTracker {
             
             return 1;                       # state fetch failed.
         } else {
-            
             $view configure -state $state
 	    #
 	    #  Update the elapsed time if we're in a run
 	    #
 	    if {$state eq "BEGIN"} {
-		$model configure -elapsed [ElapsedTime::get]
+		ElapsedTime::begin;    #Safest way to set the zero.
+		$view configure -elapsed [ElapsedTime::get]
 	    }
         }
     }
@@ -1130,7 +1131,7 @@ snit::type RunControlActionHandler {
             $model transition HWINIT
         } elseif {$what eq "begin"} {
             $model transition BEGIN
-	    ElapsedTime::begin;	# Elapsed time packge fetches the run start time.
+
         } elseif {$what eq "end"} {
             $model transition END
         } elseif {$what eq "shutdown" } {
@@ -1491,6 +1492,7 @@ ProgramClient programs -host $mgrhost -user $mgruser
 KvClient    kv -host $mgrhost -user $mgruser
 LoggerRestClient logger -host $mgrhost -user $mgruser
 
+ElapsedTime::setKvClient kv
 
 # Make the controllers
 

--- a/main/utilities/readoutREST/rdo_RunControl.tcl
+++ b/main/utilities/readoutREST/rdo_RunControl.tcl
@@ -292,12 +292,14 @@ snit::widgetadaptor ReadoutManagerControl {
         ttk::button $win.manager.shutdown -text Shutdown \
             -command [mymethod _dispatchShutdown] \
             -state disabled
+	ttk::label $win.elapsed -text "           "
         
         grid $win.manager.statelabel $win.manager.state -sticky w
         grid $win.manager.boot $win.manager.shutdown    -sticky w -padx 3
         
         grid $parameters -columnspan 3
         grid $win.manager $control
+	grid $win.elapsed 
         
         $self configurelist $args
         

--- a/main/utilities/readoutREST/rdo_elapsedTime.tcl
+++ b/main/utilities/readoutREST/rdo_elapsedTime.tcl
@@ -1,0 +1,60 @@
+##
+#  This package provides a simple interface for determining the
+#  elapsed time. Prerequisites:
+#
+#   The configuration must have a kvstore element named 'run_start_time'
+#   The BEGIN sequence must run rdo_stamp to define when the run starts.
+#
+
+
+package provide rdo_ElapsedTime 1.0
+
+
+if {[array names env DAQTCLLIBS] ne ""} {
+    lappend auto_path $::env(DAQTCLLIBS)
+}
+
+package require kvclient
+
+
+namespace eval ElapsedTime  {
+    variable start_time "Unknown"
+    variable client
+}
+
+#
+#  Set the KVStore client
+#
+proc ElapsedTime::setKvClient {c} {
+    set ::ElapsedTime::client $c
+}
+
+#
+#  Get the begin run timestamp (if possible).
+#  We assume 0 means unknwon too.
+#
+proc ElapsedTime::begin {} {
+    if {[catch {$::ElapsedTime::client  getValue run_start_time} time]} {
+	set ElapsedTime::start_time "Unknown"
+    } else {
+	set ElapsedTime::start_time $time
+    }
+}
+#
+#  Returns a nice string to put in the elapsed time widget.
+#
+proc ElapsedTime::get {} {
+    set start $ElapsedTime::start_time
+    if {![string is integer $start]} {
+	return $start
+    } else {
+	set now [clock seconds]
+	set elapsed_secs [expr {$now -$start}]
+	set secs [expr {$elapsed_secs % 60}]
+	set min  [expr {int($elapsed_secs / 60) % 60}]
+	set hrs  [expr {int($elapsed_secs/ 3600) %3600}]
+
+	return [format "%d:%02d:%02d" $hrs $min $secs]
+    }
+}
+

--- a/main/utilities/readoutREST/rdo_stamp.tcl
+++ b/main/utilities/readoutREST/rdo_stamp.tcl
@@ -1,3 +1,9 @@
+#!/bin/sh
+# -*- tcl -*-
+# The next line is executed by /bin/sh, but not tcl \
+exec tclsh "$0" ${1+"$@"}
+
+
 ##
 #   rdo_stamp.tcl
 #     This program should be added to the end of the BEGIN sequence.

--- a/main/utilities/readoutREST/rdo_stamp.tcl
+++ b/main/utilities/readoutREST/rdo_stamp.tcl
@@ -1,0 +1,58 @@
+##
+#   rdo_stamp.tcl
+#     This program should be added to the end of the BEGIN sequence.
+#     it will set the value of the KVStore variable:
+#     run_start_time to the current [clock seconds]
+#
+#     This provides a timebase for the ReadouControl script to
+#     provide a running time for active runs.
+#
+# Usage:
+#   rdo_stamp.tcl -host manager_host -user manager_user
+#
+#   where
+#      -host is the host the experiment manager is running in and
+#      -user is the name of the user who started the manager.
+#
+
+#  Pull in the kvclient package we need:
+
+if {[array names env DAQTCLLIBS] ne ""} {
+    lappend auto_path $::env(DAQTCLLIBS)
+}
+
+package require kvclient
+
+set varname run_start_time
+
+##
+#   Print he program usage to stderr and exit:
+#
+proc usage {} {
+    puts stderr "Usage:"
+    puts stderr "    rdo_stamp -host manager_host -user manager_user"
+    puts stderr "Where:"
+    puts stderr "   manager_host is the host (IP or DNS name) where the manager"
+    puts stderr "                is running"
+    puts stderr "   manager_user is the name of the user that started the manager"
+    exit -1
+}
+
+
+
+#   Main entry point:
+
+if {[llength $argv] != 2} {
+    usage
+}
+
+set host [lindex $argv 0]
+set user [lindex $argv 1]
+
+#  Set the variable to the appropriate value
+
+KvClient c -host $host -user $user
+
+c setValue $varname [clock seconds]
+
+c destroy


### PR DESCRIPTION
For 12.0, provide an elapsed run time in the managed experiment readout GUI.  This requires at least 12.0-012 and some user assistance.
*  They must create a kvstore variable named ```run_start_time```
*   They must add a program, call it e.g. ```begin_stamp``` that runs ```$DAQBIN/rdo_stamp```  it takes the host and user running the manager server as parameters.
*   ```begin_stamp``` must be run in a sequence triggered by the **BEGIN** transition at a point when the user wants the run to be declared as started.

#### How this works:

$DAQBIN/rdo_stamp stores the unix time stamp at the time it was run in to ```run_start_time```
The ```$DAQBIN/rdo_RunCOntrol```, when the state is BEGIN, uses the difference between that time stamp and the current time to maintain the text in a label that shows the elapsed time.

```