### PR TITLE
Rfoxkendo/issue48  Suports using the NSCLDAQ_DEFAULT_RINGMBYTES env variable.

### DIFF
--- a/main/base/dataflow/CRingBuffer.cpp
+++ b/main/base/dataflow/CRingBuffer.cpp
@@ -60,7 +60,7 @@ static string localhost("127.0.0.1");
 // Returns the default data size:
 
 static size_t defaultDataSize() {
-    cout << "default data size\n";
+  
     const char* pStrDefault = getenv("NSCLDAQ_DEFAULT_RINGMBYTES");
 
     if (!pStrDefault) {
@@ -469,6 +469,11 @@ size_t
 CRingBuffer::getDefaultRingSize()
 {
   return m_defaultDataSize;
+}
+
+size_t
+CRingBuffer::getInitialDefaultRingSize() {
+  return defaultDataSize();
 }
 /*!
   Set the default maximum consumer count.

--- a/main/base/dataflow/CRingBuffer.cpp
+++ b/main/base/dataflow/CRingBuffer.cpp
@@ -40,6 +40,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <daqshm.h>
+#include <stdlib.h>
 
 #include <iostream>
 
@@ -56,9 +57,35 @@ static string localhost("127.0.0.1");
 */
 
 
+// Returns the default data size:
+
+static size_t defaultDataSize() {
+    const char* pStrDefault = getenv("NSCLDAQ_DEFAULT_RINGMBYTES");
+    if (!pStrDefault) {
+      return DEFAULT_DATASIZE;
+    }
+    // Try to convert to a number:
+
+    char* endptr;
+    unsigned long mbytes = strtoul(pStrDefault, &endptr, 0);
+
+    // Return the normal default if it did not convert:
+
+    if (endptr == pStrDefault) {
+      return DEFAULT_DATASIZE;
+    }
+    // In mbytes:
+
+    size_t nBytes = mbytes;
+    nBytes *= 1024*1024;
+
+    return nBytes;
+
+}
+
 // Class Data.
 
-size_t CRingBuffer::m_defaultDataSize(DEFAULT_DATASIZE);
+size_t CRingBuffer::m_defaultDataSize(defaultDataSize());
 size_t CRingBuffer::m_defaultMaxConsumers(DEFAULT_MAX_CONSUMERS);
 
 CRingMaster* CRingBuffer::m_pMaster(NULL);

--- a/main/base/dataflow/CRingBuffer.cpp
+++ b/main/base/dataflow/CRingBuffer.cpp
@@ -68,7 +68,7 @@ static size_t defaultDataSize() {
     }
     // Try to convert to a number:
 
-    cout << "Env var: " << pStrDefault <<  std::endl;
+
     char* endptr;
     unsigned long mbytes = strtoul(pStrDefault, &endptr, 0);
 
@@ -81,7 +81,6 @@ static size_t defaultDataSize() {
 
     size_t nBytes = mbytes;
     nBytes *= 1024*1024;
-    std::cout << " Size in bytes: " << nBytes << std::endl;
     return nBytes;
 
 }
@@ -158,7 +157,7 @@ CRingBuffer::create(std::string name,
 		     bool   tempMasterConnection)
 {
 
-  std::cout << "Size: " << dataBytes << std::endl;
+
     // Figure out the entire size of the shared memory region and truncate the file to that
     // size:
     size_t headerSize = sizeof(RingHeader) +

--- a/main/base/dataflow/CRingBuffer.cpp
+++ b/main/base/dataflow/CRingBuffer.cpp
@@ -60,12 +60,15 @@ static string localhost("127.0.0.1");
 // Returns the default data size:
 
 static size_t defaultDataSize() {
+    cout << "default data size\n";
     const char* pStrDefault = getenv("NSCLDAQ_DEFAULT_RINGMBYTES");
+
     if (!pStrDefault) {
       return DEFAULT_DATASIZE;
     }
     // Try to convert to a number:
 
+    cout << "Env var: " << pStrDefault <<  std::endl;
     char* endptr;
     unsigned long mbytes = strtoul(pStrDefault, &endptr, 0);
 
@@ -78,7 +81,7 @@ static size_t defaultDataSize() {
 
     size_t nBytes = mbytes;
     nBytes *= 1024*1024;
-
+    std::cout << " Size in bytes: " << nBytes << std::endl;
     return nBytes;
 
 }
@@ -155,6 +158,7 @@ CRingBuffer::create(std::string name,
 		     bool   tempMasterConnection)
 {
 
+  std::cout << "Size: " << dataBytes << std::endl;
     // Figure out the entire size of the shared memory region and truncate the file to that
     // size:
     size_t headerSize = sizeof(RingHeader) +

--- a/main/base/dataflow/CRingBuffer.h
+++ b/main/base/dataflow/CRingBuffer.h
@@ -89,6 +89,7 @@ public:
   static bool isRing(std::string name);
   static void   setDefaultRingSize(size_t byteCount);
   static size_t getDefaultRingSize();
+  static size_t getInitialDefaultRingSize();
   static void   setDefaultMaxConsumers(size_t numConsumers);
   static size_t getDefaultMaxConsumers();
   static std::string defaultRing();

--- a/main/base/dataflow/StaticTests.cpp
+++ b/main/base/dataflow/StaticTests.cpp
@@ -13,6 +13,9 @@
 #include <errno.h>
 #include <string.h>
 
+#include <sstream>
+
+
 #include <ErrnoException.h>
 
 #include "ringbufint.h"
@@ -43,6 +46,8 @@ class StaticRingTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(isring);
   CPPUNIT_TEST(ringname);
   CPPUNIT_TEST(ringUrl);
+  CPPUNIT_TEST(defaultSize_1);
+  CPPUNIT_TEST(defaultSize_2);
   CPPUNIT_TEST_SUITE_END();
 
 
@@ -79,6 +84,8 @@ protected:
   void isring();
   void ringname();
   void ringUrl();
+  void defaultSize_1();
+  void defaultSize_2();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(StaticRingTest);
@@ -252,4 +259,26 @@ StaticRingTest::ringUrl()
   url += username;
   std::string defaultUrl = CRingBuffer::defaultRingUrl();
   EQ(url, defaultUrl);
+}
+
+// Default size will get set to DEFAULT_DATASIZE If env not defined:
+
+void StaticRingTest::defaultSize_1() {
+  unsetenv("NSCLDAQ_DEFAULT_RINGMBYTES");  // Make sure it's not defined.
+
+  auto size = CRingBuffer::getInitialDefaultRingSize();
+  EQ(size_t(DEFAULT_DATASIZE), size);
+}
+
+// Default size set to env variable if defined:
+
+void StaticRingTest::defaultSize_2() {
+  std::stringstream mbytes;
+  mbytes << "32";
+  std::string m = mbytes.str();
+
+  setenv("NSCLDAQ_DEFAULT_RINGMBYTES", m.c_str(), 1);
+
+  auto size = CRingBuffer::getInitialDefaultRingSize();
+  EQ(size_t(32*1024*1024), size);
 }

--- a/main/base/dataflow/ringbuffer.tcl
+++ b/main/base/dataflow/ringbuffer.tcl
@@ -62,6 +62,12 @@ package require report
 #  Global variables:
 
 set defaultDataSize     8m
+if {[array names env NSCLDAQ_DEFAULT_RINGMBYTES] eq "NSCLDAQ_DEFAULT_RINGMBYTES"} {
+    set s  $env(NSCLDAQ_DEFAULT_RINGMBYTES)
+    if {[string is integer $s]} {
+        set defaultDataSize  ${s}m
+    }
+}
 set defaultMaxConsumers 100
 set defaultHostname     localhost
 

--- a/main/base/dataflow/ringbuffer_man.xml
+++ b/main/base/dataflow/ringbuffer_man.xml
@@ -75,6 +75,11 @@ ringbuffer list   <replaceable>?--host=hostname?</replaceable>
                     idea to avoid characters that have special meaning to Tcl
                     as well.
 		</para>
+        <para>
+            If the environment variable <literal>NSCLDAQ_DEFAULT_RINGMBYTES</literal> is defined and
+            can be decoded as an integer, the value sets the default megabytes of ring buffer data size.
+            <option>--datasize</option> can be used to explicitly set the data size.
+        </para>
 	    </listitem>
 	</varlistentry>
         <varlistentry>

--- a/main/base/dataflow/ringbuffer_user.xml
+++ b/main/base/dataflow/ringbuffer_user.xml
@@ -90,6 +90,27 @@
       processes. For illustration, I will delete the ring I just
       created.
     </para>
+    <para>
+      The default value for data-size is normally large enough but there are two ways
+      to modify it:
+      <orderedlist>
+        <listitem><para>
+          The <command>ringbuffer create</command> can accept the command option
+          <option>--datasize</option> which allows you to specify the size of the
+          data part of the ringbuffer.  For example
+          <command>ringbuffer create myring --datasize=30m </command> makes the
+          ringbuffer <literal>myring</literal> with a 30Mbyte data size.
+        </para></listitem>
+        <listitem><para>
+          If the environment variable NSCLDAQ_DEFAULT_RINGMBYTES is defined and can be
+          evaluated as an integer, it will be the default data size for all ring buffers
+          created in megabytes.
+        </para></listitem>
+      </orderedlist>
+    </para>
+    <para>
+      Note that in the description above a megabytes is <literal>1024*1024</literal> bytes.
+    </para>
     <screen>
 <literal>spdaqxx&gt;</literal> <command>ringbuffer delete myring</command>
 <literal>spdaqxx&gt;</literal> <command>ringbuffer status</command>

--- a/main/base/dataflow/ringprimitives.xml
+++ b/main/base/dataflow/ringprimitives.xml
@@ -643,6 +643,13 @@ int main(int argc, char** argv)
         Ring buffer names can be just about anything as long as there are no
         <literal>/</literal> characters embedded in them.
       </para>
+      <para>
+        <varname>m_defaultDataSize</varname> is set from a compilation constant in NSCLDAQ
+        however it can be overidden by defining the environment variable
+        <literal>NSCLDAQ_DEFAULT_RINGMBYTES</literal> to be an integer number of megabytes
+        that will replace the compiled value of <varname>m_defaultDataSize</varname> effectively
+        setting the default ring buffer data size.
+      </para>
     <variablelist>
         <varlistentry>
             <term><type>std::string</type> <parameter>name</parameter></term>

--- a/main/usb/vmusb/vmusbReadout_man.xml
+++ b/main/usb/vmusb/vmusbReadout_man.xml
@@ -7917,7 +7917,7 @@ mdpp32qdc cget <replaceable>name</replaceable>
                          <para>
                            MDPPTriggerControl GUI is included in the FRIBDAQ package. This value needs to be set to 0x400
                            to use the GUI controller. In this case, the last setting is preserved while start/stop runs.
-                         </param>
+                         </para>
                          <informalexample>
                              <programlisting>
 +-------------------------------------------+
@@ -7944,7 +7944,7 @@ mdpp32qdc cget <replaceable>name</replaceable>
                          <para>
                            MDPPTriggerControl GUI is included in the FRIBDAQ package. This value needs to be set to 0x400
                            to use the GUI controller. In this case, the last setting is preserved while start/stop runs.
-                         </param>
+                         </para>
                          <informalexample>
                              <programlisting>
 +-----------------------------------------+
@@ -8804,7 +8804,7 @@ mdpp16qdc cget <replaceable>name</replaceable>
                          <para>
                            MDPPTriggerControl GUI is included in the FRIBDAQ package. This value needs to be set to 0x400
                            to use the GUI controller. In this case, the last setting is preserved while start/stop runs.
-                         </param>
+                         </para>
                          <informalexample>
                              <programlisting>
 +-------------------------------------------+
@@ -8831,7 +8831,7 @@ mdpp16qdc cget <replaceable>name</replaceable>
                          <para>
                            MDPPTriggerControl GUI is included in the FRIBDAQ package. This value needs to be set to 0x400
                            to use the GUI controller. In this case, the last setting is preserved while start/stop runs.
-                         </param>
+                         </para>
                          <informalexample>
                              <programlisting>
 +-----------------------------------------+
@@ -9643,7 +9643,7 @@ mdpp32scp cget <replaceable>name</replaceable>
                          <para>
                            MDPPTriggerControl GUI is included in the FRIBDAQ package. This value needs to be set to 0x400
                            to use the GUI controller. In this case, the last setting is preserved while start/stop runs.
-                         </param>
+                         </para>
                          <informalexample>
                              <programlisting>
 +-------------------------------------------+
@@ -9670,7 +9670,7 @@ mdpp32scp cget <replaceable>name</replaceable>
                          <para>
                            MDPPTriggerControl GUI is included in the FRIBDAQ package. This value needs to be set to 0x400
                            to use the GUI controller. In this case, the last setting is preserved while start/stop runs.
-                         </param>
+                         </para>
                          <informalexample>
                              <programlisting>
 +-----------------------------------------+


### PR DESCRIPTION
This implements issue #48 The user can set a default ringbuffers size by defining the ```NSCLDAQ_DEFAULT_RINGMBYTES``` environment variable to be an integer (before the program that makes the ring buffer starts).  That integer sets the number of *megabytes* for the default ringbuffer size.

* $DAQBIN/ringbuffer create honors this.
* CRingBuffer::create honors this.
* documented as well.