### PR TITLE
Rfoxkendo/issue99 Resolve issue #99

### DIFF
--- a/main/base/dataflow/CRemoteAccess.cpp
+++ b/main/base/dataflow/CRemoteAccess.cpp
@@ -58,7 +58,13 @@ static size_t getDefaultSize() {
   if (!pStrValue) {
     return DEFAULT_DATASIZE;
   }
-  
+  char* pEnd;
+  size_t result = strtoul(pStrValue, &pEnd, 0);
+  if (pEnd == pStrValue) {
+    return DEFAULT_DATASIZE;
+  } else {
+    return result*1024*1024;
+  }
 }
 
 /*!
@@ -126,7 +132,14 @@ CRingAccess::getProxyRingSize()
 {
   return m_proxyRingSize;
 }
-
+/**
+ * getDefaultProxyRingSize - mostly for testing... determine what the proxy
+ * ring size would be if allowed to default (just call getDefaultSize);
+*/
+size_t
+CRingAccess::getDefaultProxyRingSize() {
+  return getDefaultSize();
+}
 /*!
    Set a new value for the maximum number of consumers that will be allowed
    to connect to new proxy rings.  See the comments  for setProxyRingSize, as the same caveats 

--- a/main/base/dataflow/CRemoteAccess.cpp
+++ b/main/base/dataflow/CRemoteAccess.cpp
@@ -49,12 +49,12 @@ using namespace std;
 /** 
  * getDefaultSize 
  *    Return the default ring size.  This is either DEFAULT_DATASIZE or,
- *   if the environment variable NSCLDAQ_DEFAULT_PROXYMBYTES is
+ *   if the environment variable NSCLDAQ_DEFAULT_PROXYMB is
  *   defined and translates to an unsigned
  *   integer, the number of megabytes specified by that env variable.
 */
 static size_t getDefaultSize() {
-  const char* pStrValue = getenv("NSCLDAQ_DEFAULT_PROXYMBYTES");
+  const char* pStrValue = getenv("NSCLDAQ_DEFAULT_PROXYMB");
   if (!pStrValue) {
     return DEFAULT_DATASIZE;
   }

--- a/main/base/dataflow/CRemoteAccess.cpp
+++ b/main/base/dataflow/CRemoteAccess.cpp
@@ -46,11 +46,26 @@ using namespace std;
 #define K 1024
 #endif
 
+/** 
+ * getDefaultSize 
+ *    Return the default ring size.  This is either DEFAULT_DATASIZE or,
+ *   if the environment variable NSCLDAQ_DEFAULT_PROXYMBYTES is
+ *   defined and translates to an unsigned
+ *   integer, the number of megabytes specified by that env variable.
+*/
+static size_t getDefaultSize() {
+  const char* pStrValue = getenv("NSCLDAQ_DEFAULT_PROXYMBYTES");
+  if (!pStrValue) {
+    return DEFAULT_DATASIZE;
+  }
+  
+}
+
 /*!
    This static member determines the size of the data area of a proxy ring buffer.
    The CRingAccess:set/getProxyRingSize members can modify/read this value.
 */
-size_t CRingAccess::m_proxyRingSize(DEFAULT_DATASIZE);
+size_t CRingAccess::m_proxyRingSize(getDefaultSize());
 
 /*!
    This static member determines the number of consumers that will be allowed to 

--- a/main/base/dataflow/CRemoteAccess.h
+++ b/main/base/dataflow/CRemoteAccess.h
@@ -58,6 +58,7 @@ private:
 public:
   static size_t setProxyRingSize(size_t newSize);
   static size_t getProxyRingSize();
+  static size_t   getDefaultProxyRingSize();
   
   static size_t setProxyMaxConsumers(size_t newMax);
   static size_t getProxyMaxConsumers();
@@ -67,6 +68,7 @@ public:
 
   static unsigned setTimeout(unsigned newTimeout);
   static unsigned getTimeout();
+  
 
 
   static CRingBuffer* daqConsumeFrom(std::string uri);

--- a/main/base/dataflow/RemoteTests.cpp
+++ b/main/base/dataflow/RemoteTests.cpp
@@ -5,11 +5,15 @@
 #include "Asserts.h"
 #include <CRingMaster.h>
 #include <CRingBuffer.h>
+#include "ringbufint.h"
 #include <CRemoteAccess.h>
 #include <string.h>
 #include "testcommon.h"
+#include <stdlib.h>
 
 using namespace std;
+
+const char* sizeEnv = "NSCLDAQ_DEFAULT_PROXYMB";
 
 class RemoteTests : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(RemoteTests);
@@ -19,6 +23,9 @@ class RemoteTests : public CppUnit::TestFixture {
   CPPUNIT_TEST(timeoutTest);
   CPPUNIT_TEST(urllocal);
   CPPUNIT_TEST(urlremote);
+  CPPUNIT_TEST(default_1);
+  CPPUNIT_TEST(default_2);
+  CPPUNIT_TEST(default_3);
   CPPUNIT_TEST_SUITE_END();
 
 
@@ -38,6 +45,10 @@ protected:
   void timeoutTest();
   void urllocal();
   void urlremote();
+
+  void default_1();
+  void default_2();
+  void default_3();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(RemoteTests);
@@ -211,4 +222,23 @@ RemoteTests::urlremote()
 
   ASSERT(!caught);
   delete pConsumer;		// Destroy the proxy ring.
+}
+
+void RemoteTests::default_1() {
+  // With no env name, we get DEFAULT_DATASIZE:
+
+  unsetenv(sizeEnv);         // Make sure it's not defined.
+
+  EQ(size_t(DEFAULT_DATASIZE), CRingAccess::getDefaultProxyRingSize());
+}
+void RemoteTests::default_2() {
+  // Valid size modifies the default:
+  setenv(sizeEnv, "10", 1);    //  10mbytes.
+  EQ(size_t(1024*1024*10), CRingAccess::getDefaultProxyRingSize());
+}
+void RemoteTests::default_3() {
+  // Invalid size silently falls back to the default.
+
+  setenv(sizeEnv, "Ron", 1);   // invalid integer.
+  EQ(size_t(DEFAULT_DATASIZE), CRingAccess::getDefaultProxyRingSize());
 }

--- a/main/base/dataflow/RemoteTests.cpp
+++ b/main/base/dataflow/RemoteTests.cpp
@@ -46,6 +46,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RemoteTests);
 
 void RemoteTests::sizeTest() 
 {
+  
   size_t value = CRingAccess::getProxyRingSize();
   size_t old   = CRingAccess::setProxyRingSize(value*2);
   EQ(old, value);

--- a/main/base/dataflow/ringlib.xml
+++ b/main/base/dataflow/ringlib.xml
@@ -68,6 +68,11 @@ g++ -o myprogram myprogram.cpp -L$DAQROOT/lib -ldataflow -Wl,"-rpath=$DAQROOT/li
         remote ring are simply connected to the proxy ring.
     </para>
     <para>
+        The size of the local proxy ringbuffer defaults to 8MB.  This can be modified
+        by setting the environment variable <literal>NSCLDAQ_DEFAULT_PROXYMB</literal>
+        to the desired proxy ringbuffer size in MegaBytes.
+    </para>
+    <para>
         The networked ring buffer access class
         <classname>CRingAccess</classname> provides member functions that make
         this operation completely transparent to application code.  Ring buffers

--- a/main/base/dataflow/ringmaster.xml
+++ b/main/base/dataflow/ringmaster.xml
@@ -270,6 +270,11 @@
             and arranging for data from the ring to be copied to the proxy ring.
         </para>
         <para>
+            The size of the local proxy ring defaults to 8Megabytes.  This can be
+            altered to suit your application by setting the environment variable
+            NSCLDAQ_DEFAULT_PROXYMB to the desired number of megabytes for proxy ringbuffers.
+        </para>
+        <para>
             The
             <literal>REMOTE</literal>
             command requests data from a ring.  If successful, the


### PR DESCRIPTION
This pull request incoprorates the resolution of issue #99 into 12.1-dev.

*  If the environment variable NSCLDAQ_DEFAULT_PROXYMB is defined and a valid integer it sets the number of MB of data space for proxy rings.
*  Includes tests for the above.
* Documents the above.