### PR TITLE
Rfoxkendo/issue97

### DIFF
--- a/main/simplesetups/vmusb/src/CRawADCUnpacker.cpp
+++ b/main/simplesetups/vmusb/src/CRawADCUnpacker.cpp
@@ -176,7 +176,7 @@ void CRawADCUnpacker::unpackEOE(uint32_t word, ParsedADCEvent& event)
   event.s_eventNumber = (word & TRAIL_COUNT_MASK);
 }
 
-void CRawAdcUnpacker::incompleteEvent(const char* whence)
+void CRawADCUnpacker::incompleteEvent(const char* whence)
 {
   string errmsg(whence);
   errmsg += "Incomplete event found in buffer.";

--- a/main/simplesetups/vmusb/src/MySpecTclApp.cpp
+++ b/main/simplesetups/vmusb/src/MySpecTclApp.cpp
@@ -305,6 +305,12 @@ CMySpecTclApp::operator()()
 }
 
 CMySpecTclApp   myApp;
-CTclGrammerApp& app(myApp);	// Create an instance of me.
+#ifdef SPECTCL_5_INIT
+CTclGrammerApp* CTclGrammerApp::m_pInstance = &myApp;
+CTCLApplication* gpTCLApplication;
+
+#else
+CTclGrammerApp& app(myApp);     // Create an instance of me.
 CTCLApplication* gpTCLApplication=&app;  // Findable by the Tcl/tk framework.
+#endif
 


### PR DESCRIPTION
Resolve issue #97 - Errors in simple setup vmusb SpecTcl files:

*  Change ```CRawAdcUnpacker::incompleteEvent```  to ```CRawADCUnpacker::incompleteEvent``` (see change in ADC capitalization.
* Add the version 5 conditional magic to MySpecTclApp.cpp
* Test build against 5.14-000.
