### PR TITLE
Use Os::whoami not getenv(LOGNAME)  in ring naming tests as LOGNAME

### DIFF
--- a/main/base/dataflow/StaticTests.cpp
+++ b/main/base/dataflow/StaticTests.cpp
@@ -17,6 +17,7 @@
 
 #include "ringbufint.h"
 #include "testcommon.h"
+#include <os.h>
 
 using namespace std;
 
@@ -240,14 +241,14 @@ StaticRingTest::isring()
 void
 StaticRingTest::ringname()
 {
-  std::string username= getenv("LOGNAME");
+  std::string username= Os::whoami();
   std::string defaultName = CRingBuffer::defaultRing();
   EQ(username, defaultName);
 }
 void
 StaticRingTest::ringUrl()
 {
-  std::string username = getenv("LOGNAME");
+  std::string username = Os::whoami();
   std::string url      = "tcp://localhost/";
   url += username;
   std::string defaultUrl = CRingBuffer::defaultRingUrl();


### PR DESCRIPTION
is not reliable -e.g does not exist on github