### PR TITLE
*   Fix error in delay provider's end-1 test incorrect parameter to d…

### DIFF
--- a/main/daq/readoutgui/Makefile.am
+++ b/main/daq/readoutgui/Makefile.am
@@ -45,11 +45,16 @@ TCLPACKAGES=Configuration.tcl \
 
 
 
+# sshpipe.test - that can really only run if a system and the user are properly# set up.
+
 TCLTESTS =    filesystem.test \
 	initconfig.test installroot.test system.test tests.test  ostest.test \
-	sshpipe.test s800.test  rstatemachine.test rdocallouts.test \
+	s800.test  rstatemachine.test rdocallouts.test \
 	  state.test  delayprovider.test \
 		applauncher.test bundlemgr.test
+
+# to enable sshpipe.test uncomment the next line:
+#TCLTESTS+=sshpipe.test
 
 
 TKTESTS =	readoutguitest.tk  scalerparametergui.tk \

--- a/main/daq/readoutgui/delayprovider.test
+++ b/main/daq/readoutgui/delayprovider.test
@@ -83,10 +83,12 @@ tcltest::test end-0 {Test that end of run delay is as long we expect
 
 } -result 1 -returnCodes 0
 
+# Delay 11ms and hope it's at least 10ms
+
 tcltest::test end-1 {Short delay works} \
 -body {
 
-  Delay::start [dict create delay 0 enddelay 1 sourceid 0]
+  Delay::start [dict create delay 0 enddelay 11 sourceid 0]
   set start [clock milliseconds]
   ::Delay::end 0
   set stop [clock milliseconds]


### PR DESCRIPTION
…elay end.

*   Make sshpipe.test not run unless a line in the Makefile.am is commented out or it's run by hand.  Running that test requires that:
    1.  The sshd be runing.
    2.  The user running the test has setup ssh keys to allow ssh localhost with no login.