### PR TITLE
Issue #140 - Scaler display crashes on alarms

### DIFF
--- a/main/base/tclwidgets/blockimage.tcl
+++ b/main/base/tclwidgets/blockimage.tcl
@@ -50,3 +50,33 @@ proc makeBlock {name color width height} {
     
     return $name
 }
+
+##
+# getColorImage
+#   Gets a large, cached color image (uses makeBlock above) 
+#   suitable for using as background for widgets (which will clip it)
+#   The images are cached so that they are not continuously remade.
+#
+#  @param color - color of the widget to be made.
+#  @return image handle.
+#  
+
+namespace eval ColorImageCache {
+    array set cache [list] ;    # The image cache indexed by color.
+}
+
+proc getColorImage {color} {
+    # See if the request can be fulfilled from the cache
+
+    if {[array names ColorImageCache::cache $color] eq $color} {
+        return $ColorImageCache::cache($color)
+    }
+
+    # Have to make a new one
+
+    set name getColorImage.$color
+    set result [makeBlock $name $color 71 25] 
+
+    set ColorImageCache::cache($color) $result
+    return $result
+}

--- a/main/utilities/newscaler/scalerconfig.tcl
+++ b/main/utilities/newscaler/scalerconfig.tcl
@@ -44,7 +44,7 @@ namespace eval ::scalerconfig {
     
     variable lowAlarmTabColor  green
     variable highAlarmTabColor red
-    variable bothAlarmTabColor amber
+    variable bothAlarmTabColor goldenrod
 
 }
 

--- a/main/utilities/newscaler/scalermain.tcl
+++ b/main/utilities/newscaler/scalermain.tcl
@@ -54,7 +54,7 @@ package require scalerReport
 package require Plotchart::xyplotContainer
 package require scaleControl
 package require zoomPrompt
-
+package require blockimage
 
 ## Ensure the user supplied a configuration file:
 
@@ -299,7 +299,7 @@ proc startAcqThread {ringUrl} {
     set myThread [thread::id]
     set getItems "proc getItems {tid uri} { 
         while 1 {                                             
-            set ringItem \[ring get \$uri {1 2 20}]             
+            set ringItem \[ring get \$uri {1 2 20}]  
             thread::send \$tid \[list handleData \$ringItem]     
         }                                                     
     }                                                         
@@ -612,6 +612,7 @@ proc endRun   {item} {
 proc handleData item {
     #puts $item
     # Dispatch based on the type of event:
+    
     
     set type [dict get $item type]
     switch $type {


### PR DESCRIPTION
*  Write the missing getColorImage proc and put it in blockimage.tcl
*  Require the blockimage package in scalermain.tcl
*  In scalerconfig.tcl since amber is not a Tcl color change that to goldenrod which is pretty much an amber color.
Fix for issue #140 