### PR TITLE
Rfoxkendo/issue124

### DIFF
--- a/main/daq/IO/CDataSink.h
+++ b/main/daq/IO/CDataSink.h
@@ -41,7 +41,7 @@ public:
     * Instead of using this method, the user should use the overload of the
     * insertion operator (operator<<) for CRingItems.
     */
-    virtual void putItem(const CRingItem& item) =0;
+    virtual void putItem(const ::CRingItem& item) =0;
     
   /*!
      * \brief Write a block of data to the sink

--- a/main/ddas/ddasdumper/DataSource.h
+++ b/main/ddas/ddasdumper/DataSource.h
@@ -23,10 +23,11 @@
  * @brief Works with factories to provide a data source for undifferentiated 
  * ring items.
  */
-
-class CRingItem;
-class RingItemFactoryBase;
-
+namespace ufmt {
+    class CRingItem;
+    class RingItemFactoryBase;
+}
+using namespace ufmt;
 /**
  * @class DataSource
  * @brief Abstract base class for DDAS data sources.

--- a/main/ddas/ddasdumper/FdDataSource.h
+++ b/main/ddas/ddasdumper/FdDataSource.h
@@ -24,6 +24,7 @@
 
 #include "DataSource.h"
 
+using namespace ufmt;
 /**
  * @class FdDataSource
  * @brief A class taking the file descriptor as a data source. Most commonly 

--- a/main/ddas/ddasdumper/RootFileDataSink.cpp
+++ b/main/ddas/ddasdumper/RootFileDataSink.cpp
@@ -49,7 +49,7 @@ static const Int_t BUFFERSIZE(1024*1024); // 1 MB
  * our operation.
  */
 RootFileDataSink::RootFileDataSink(
-    RingItemFactoryBase* pFactory, const char* fileName, const char* treeName
+    ufmt::RingItemFactoryBase* pFactory, const char* fileName, const char* treeName
     ) :
     m_pFactory(pFactory), m_pUnpacker(new DAQ::DDAS::DDASHitUnpacker),
     m_pEvent(new DDASRootEvent), m_pTree(nullptr), m_pFile(nullptr),
@@ -95,7 +95,7 @@ RootFileDataSink::~RootFileDataSink()
  * that's done we can fill the tree and delete any dynamic storage we got.
  */
 void
-RootFileDataSink::putItem(const CRingItem& item)
+RootFileDataSink::putItem(const ::ufmt::CRingItem& item)
 {
     try {
 	const uint32_t* pBody
@@ -124,11 +124,11 @@ RootFileDataSink::putItem(const CRingItem& item)
 	    // Use the factory to make a ring item out of the fragment
 	    // and get a pointer to its body:
     
-	    const RingItem* pFrag = reinterpret_cast<const RingItem*>(pBody);
-	    std::unique_ptr<CRingItem> pUndiff(
-		m_pFactory->makeRingItem(pFrag)
+	    const ::ufmt::RingItem* pFrag = reinterpret_cast<const ::ufmt::RingItem*>(pBody);
+	    std::unique_ptr<ufmt::CRingItem> pUndiff(
+			m_pFactory->makeRingItem(pFrag)
 		);
-	    std::unique_ptr<CPhysicsEventItem> pPhysics(
+	    std::unique_ptr<::ufmt:: CPhysicsEventItem> pPhysics(
 		m_pFactory->makePhysicsEventItem(*pUndiff)
 		);
 	    const uint32_t* pFragBody
@@ -191,7 +191,7 @@ RootFileDataSink::put(const void* pData, size_t nBytes)
 	std::cerr << msg << std::endl;
     }
     
-    const RingItem* pRawItem = reinterpret_cast<const RingItem*>(pData);
-    std::unique_ptr<CRingItem> pItem(m_pFactory->makeRingItem(pRawItem));
+    const ::ufmt::RingItem* pRawItem = reinterpret_cast<const ::ufmt::RingItem*>(pData);
+    std::unique_ptr<::ufmt::CRingItem> pItem(m_pFactory->makeRingItem(pRawItem));
     putItem(*pItem.get());
 }

--- a/main/ddas/ddasdumper/RootFileDataSink.h
+++ b/main/ddas/ddasdumper/RootFileDataSink.h
@@ -23,8 +23,7 @@
 
 #ifndef ROOTFILEDATASINK_H
 #define ROOTFILEDATASINK_H
-
-#include <CDataSink.h>
+#include <stdlib.h>
 
 class TTree;
 class TFile;
@@ -35,7 +34,10 @@ namespace DAQ {
     }
 }
 class DDASRootEvent; // Holds the decoded event for output.
-class RingItemFactoryBase;
+namespace ufmt {
+    class RingItemFactoryBase;
+    class CRingItem;
+}
 
 /**
  * @class RootFileDataSink
@@ -47,10 +49,10 @@ class RingItemFactoryBase;
  * on. The behavior in this case is likely undefined.
  */
 
-class RootFileDataSink : public CDataSink
+class RootFileDataSink 
 {
 private:
-    RingItemFactoryBase* m_pFactory; //!< Turns bodies into ring items.
+    ufmt::RingItemFactoryBase* m_pFactory; //!< Turns bodies into ring items.
     DAQ::DDAS::DDASHitUnpacker* m_pUnpacker; //!< Unpacker for our hits.
     DDASRootEvent* m_pEvent;         //!< The ROOT-ized event to write.
     TTree* m_pTree;                  //!< Tree in the output file we write to.
@@ -67,7 +69,7 @@ public:
      * @throw All exceptions back to the caller.
      */
     RootFileDataSink(
-	RingItemFactoryBase* pFactory, const char* fileName,
+	ufmt::RingItemFactoryBase* pFactory, const char* fileName,
 	const char* treeName="ddas"
 	);
     /** @brief Destructor. */
@@ -79,7 +81,7 @@ public:
      * @param item Reference to a ring item object.
      * @throw std::length_error If the event size is different than expected.
      */
-    virtual void putItem(const CRingItem& item);
+    virtual void putItem(const ::ufmt::CRingItem& item);
     /**
      * @brief Called to put arbitrary data to the file. 
      * @param pData  Pointer to the data.

--- a/main/ddas/ddasdumper/ddasdumper.cpp
+++ b/main/ddas/ddasdumper/ddasdumper.cpp
@@ -61,6 +61,7 @@
 #include "StreamDataSource.h"
 #include "RootFileDataSink.h"
 
+using namespace ufmt;
 // Map of exclusion type strings to type integers:
 
 static std::map<std::string, uint32_t> TypeMap = {
@@ -196,7 +197,7 @@ mapVersion(enum_format fmtIn)
  * @return Dynamically allocated data source.
  */
 DataSource*
-makeDataSource(RingItemFactoryBase* pFactory, const std::string& strUrl)
+makeDataSource(::ufmt::RingItemFactoryBase* pFactory, const std::string& strUrl)
 {
     // Special case the url is just "-" then it's stdin, a file descriptor
     // data source:
@@ -255,8 +256,8 @@ makeDataSource(RingItemFactoryBase* pFactory, const std::string& strUrl)
  */
 static void
 dumpItem(
-    CRingItem* pItem, RingItemFactoryBase& factory,
-    CDataSink* pSink
+    ::ufmt::CRingItem* pItem, ::ufmt::RingItemFactoryBase& factory,
+    RootFileDataSink* pSink
     )
 {
     /** 
@@ -402,7 +403,7 @@ main(int argc, char* argv[])
 	
 	if (skipCount > 0) {
             for (int i = 0; i < skipCount; i++) {
-                std::unique_ptr<CRingItem> p(pSource->getItem());
+                std::unique_ptr<::ufmt::CRingItem> p(pSource->getItem());
                 if (!p.get()) { // End of source.
 		    std::cout << "End of data source encountered while "
 			      << "processing --skip items, exiting.\n";
@@ -416,7 +417,7 @@ main(int argc, char* argv[])
 
 	int remaining = dumpCount;
 	while (1) {
-	    std::unique_ptr<CRingItem> pItem(pSource->getItem());
+	    std::unique_ptr<::ufmt::CRingItem> pItem(pSource->getItem());
             if (!pItem.get()) { // End of source.
 		return EXIT_SUCCESS;
             }

--- a/main/unifiedfmt-incorp.sh
+++ b/main/unifiedfmt-incorp.sh
@@ -2,7 +2,7 @@
 
 ##  Incorporate the unfied formatting library:
 
-# Most recently used version 1.2
+# Most recently used version 2.0
 
 REPOSITORY="https://github.com/FRIBDAQ/UnifiedFormat.git"
 TAG=$1
@@ -10,7 +10,7 @@ TARGET="unifiedformat"
 
 if [[ ! $TAG ]]
 then
-  TAG="1.2"
+  TAG="2.0"
 fi
 
 rm -rf $TARGET

--- a/main/utilities/bufdump/BufdumpMain.cpp
+++ b/main/utilities/bufdump/BufdumpMain.cpp
@@ -25,7 +25,7 @@
 #include <CDataSource.h>
 #include <CDataSourceFactory.h>
 #include <CRingScalerItem.h>
-
+#include "CUnifiedFormatter.h"
 #include "dumperargs.h"
 
 #include <iostream>
@@ -37,6 +37,8 @@
 #include <pwd.h>
 #include <sys/types.h>
 #include <stdio.h>
+
+
 
 
 using namespace std;
@@ -215,12 +217,17 @@ BufdumpMain::operator()(int argc, char** argv)
     m_skipCount--;
   }
 
+  // Make an object to give us version specific strings
+  // for the ring items:
+
+  auto formatter = CUnifiedFormatter(parse.nscldaq_version_arg);
+
   size_t numToDo = m_itemCount;
   bool done = false;
   while (!done) {
     CRingItem *pItem = pSource->getItem();
     if (pItem) {
-      processItem(*pItem);
+      processItem(*pItem, formatter);
       delete pItem;
       
       numToDo--;
@@ -249,14 +256,14 @@ BufdumpMain::operator()(int argc, char** argv)
 **    item - Reference to the item to dump.
 */
 void
-BufdumpMain::processItem(const CRingItem& item)
+BufdumpMain::processItem(const CRingItem& item, CUnifiedFormatter& formatter)
 {
 
   cout << "-----------------------------------------------------------\n";
-  CRingItem* pActualItem = CRingItemFactory::createRingItem(item);
-  cout << pActualItem->toString();
+  
+  cout << formatter(item.getItemPointer());
   cout.flush();                           // in case it's a file.
-  delete pActualItem;
+  
 
 }
 

--- a/main/utilities/bufdump/BufdumpMain.h
+++ b/main/utilities/bufdump/BufdumpMain.h
@@ -34,6 +34,8 @@ class CRingPhysicsEventCountItem;
 
 class CRingBuffer;
 
+
+
 /*!
   This class is the actual dumper program.  It defines a function object type
   that can be created and invoked from main() to do the job of dumping

--- a/main/utilities/bufdump/BufdumpMain.h
+++ b/main/utilities/bufdump/BufdumpMain.h
@@ -33,7 +33,7 @@ class CRingScalerItem;
 class CRingPhysicsEventCountItem;
 
 class CRingBuffer;
-
+class CUnifiedFormatter;
 
 
 /*!
@@ -77,7 +77,7 @@ public:
 
 private:
   CRingItem* getItem(CRingBuffer& ring);
-  void processItem(const CRingItem& item);
+  void processItem(const CRingItem& item, CUnifiedFormatter& formatter);
 
 
   std::string defaultSource() const; 

--- a/main/utilities/bufdump/CUnifiedFormatter.cpp
+++ b/main/utilities/bufdump/CUnifiedFormatter.cpp
@@ -87,6 +87,7 @@ makeActualItem(const CRingItem& raw, ::ufmt::RingItemFactoryBase& fact) {
         std::cerr << "could not convert raw ring item to specific one: \n";
         std::cerr << e.what() << std::endl;
         std::cerr << "Ring item type was: " << std::hex << "0x" << raw.type() << std::endl;
+        std::cerr << raw.toString() << std::endl;
         exit(EXIT_FAILURE);
     }
 }

--- a/main/utilities/bufdump/CUnifiedFormatter.cpp
+++ b/main/utilities/bufdump/CUnifiedFormatter.cpp
@@ -86,6 +86,7 @@ makeActualItem(const CRingItem& raw, ::ufmt::RingItemFactoryBase& fact) {
     } catch (std::exception &e){
         std::cerr << "could not convert raw ring item to specific one: \n";
         std::cerr << e.what() << std::endl;
+        std::cerr << "Ring item type was: " << std::hex << "0x" << raw.type() << std::endl;
         exit(EXIT_FAILURE);
     }
 }

--- a/main/utilities/bufdump/CUnifiedFormatter.cpp
+++ b/main/utilities/bufdump/CUnifiedFormatter.cpp
@@ -18,6 +18,20 @@
 #include <NSCLDAQFormatFactorySelector.h>  // unified fmt.
 #include <CRingItem.h>                    // unified fmt
 #include <DataFormat.h>                   // unified fmt.
+// Ring items from ufmt:
+
+#include <CAbnormalEndItem.h>
+#include <CDataFormatItem.h>
+#include <CGlomParameters.h>
+#include <CPhysicsEventItem.h>
+#include <CRingFragmentItem.h>
+#include <CRingItem.h>
+#include <CRingPhysicsEventCountItem.h>
+#include <CRingScalerItem.h>
+#include <CRingStateChangeItem.h>
+#include <CRingTextItem.h>
+#include  <CUnknownFragment.h>
+
 #include <stdexcept>
 #include <map>
 
@@ -51,7 +65,6 @@ makeActualItem(const CRingItem& raw, RingItemFactoryBase& fact) {
         return fact.makeTextItem(raw);
     case RING_FORMAT:
         return fact.makeDataFormatItem(raw);
-    case PERIODIC_SCALERS:
     case INCREMENTAL_SCALERS:
     case TIMESTAMPED_NONINCR_SCALERS:
         return fact.makeScalerItem(raw);
@@ -81,7 +94,7 @@ makeActualItem(const CRingItem& raw, RingItemFactoryBase& fact) {
  * 
  * @param version - major version of NSCLDAQ the ring items belong to.
  */
-CUnifiedFormatter::CUnifiedFormatter(int versions) : m_pFactory(0)
+CUnifiedFormatter::CUnifiedFormatter(int version) : m_pFactory(0)
 {
     auto p = versionMap.find(version);
     if (p == versionMap.end()) {
@@ -89,7 +102,7 @@ CUnifiedFormatter::CUnifiedFormatter(int versions) : m_pFactory(0)
 
         throw std::invalid_argument("Not a valid formt selector in CUnifiedFormatter constructor");
     }
-    m_pFactory = FormatSelector::selectFactory(p->second);
+    m_pFactory = &FormatSelector::selectFactory(p->second);
 }
 /**
  * destructor
@@ -110,7 +123,7 @@ CUnifiedFormatter::~CUnifiedFormatter() {
  */
 std::string
 CUnifiedFormatter::operator()(const void* pItem) {
-    const pRingItem pRaw = reinterpret_cast<const pRingitem>(pItem);
+    const RingItem* pRaw = reinterpret_cast<const RingItem*>(pItem);
 
     auto rawItem = m_pFactory->makeRingItem(pRaw);
     auto actualItem = makeActualItem(*rawItem, *m_pFactory);
@@ -118,7 +131,7 @@ CUnifiedFormatter::operator()(const void* pItem) {
     std::string result = actualItem->toString();
 
     delete rawItem;
-    delete actualItme;
+    delete actualItem;
 
 
     return result;

--- a/main/utilities/bufdump/CUnifiedFormatter.cpp
+++ b/main/utilities/bufdump/CUnifiedFormatter.cpp
@@ -32,6 +32,8 @@
 #include <CRingTextItem.h>
 #include  <CUnknownFragment.h>
 
+#include <stdlib.h>
+#include <iostream>
 #include <stdexcept>
 #include <map>
 using namespace ufmt;
@@ -52,37 +54,40 @@ makeActualItem(const CRingItem& raw, ::ufmt::RingItemFactoryBase& fact) {
     // the cases in the switch below will need to be expanded 
     // as more ring item types are defined:
 
-    switch (raw.type()) {
-    case BEGIN_RUN:
-    case END_RUN:
-    case PAUSE_RUN:
-    case RESUME_RUN:
-        return fact.makeStateChangeItem(raw);
-    case ABNORMAL_ENDRUN:
-        return fact.makeAbnormalEndItem(raw);
-    case PACKET_TYPES:
-    case MONITORED_VARIABLES:
-        return fact.makeTextItem(raw);
-    case RING_FORMAT:
-        return fact.makeDataFormatItem(raw);
-    case INCREMENTAL_SCALERS:
-    case TIMESTAMPED_NONINCR_SCALERS:
-        return fact.makeScalerItem(raw);
-    case PHYSICS_EVENT:
-        return fact.makePhysicsEventItem(raw);
-    case PHYSICS_EVENT_COUNT:
-        return fact.makePhysicsEventCountItem(raw);
-    case  EVB_FRAGMENT:
-        return fact.makeRingFragmentItem(raw);
-    case EVB_UNKNOWN_PAYLOAD:
-        return fact.makeUnknownFragment(raw);
-    case EVB_GLOM_INFO:
-        return fact.makeGlomParameters(raw);
+    try {
+        switch (raw.type()) {
+        case BEGIN_RUN:
+        case END_RUN:
+        case PAUSE_RUN:
+        case RESUME_RUN:
+            return fact.makeStateChangeItem(raw);
+        case ABNORMAL_ENDRUN:
+            return fact.makeAbnormalEndItem(raw);
+        case PACKET_TYPES:
+        case MONITORED_VARIABLES:
+            return fact.makeTextItem(raw);
+        case RING_FORMAT:
+            return fact.makeDataFormatItem(raw);
+        case INCREMENTAL_SCALERS:
+        case TIMESTAMPED_NONINCR_SCALERS:
+            return fact.makeScalerItem(raw);
+        case PHYSICS_EVENT:
+            return fact.makePhysicsEventItem(raw);
+        case PHYSICS_EVENT_COUNT:
+            return fact.makePhysicsEventCountItem(raw);
+        case  EVB_FRAGMENT:
+            return fact.makeRingFragmentItem(raw);
+        case EVB_UNKNOWN_PAYLOAD:
+            return fact.makeUnknownFragment(raw);
+        case EVB_GLOM_INFO:
+            return fact.makeGlomParameters(raw);
+        }
+        return fact.makeRingItem(raw);
+    } catch (std::exception &e){
+        std::cerr << "could not convert raw ring item to specific one: \n";
+        std::cerr << e.what() << std::endl;
+        exit(EXIT_FAILURE);
     }
-
-
-
-    return fact.makeRingItem(raw);
 }
 
 //// Implement UnifiedFormatter:

--- a/main/utilities/bufdump/CUnifiedFormatter.cpp
+++ b/main/utilities/bufdump/CUnifiedFormatter.cpp
@@ -1,0 +1,126 @@
+/*
+    This software is Copyright by the Board of Trustees of Michigan
+    State University (c) Copyright 2005.
+
+    You may use this software under the terms of the GNU public license
+    (GPL).  The terms of this license are described at:
+
+     http://www.gnu.org/licenses/gpl.txt
+
+     Author:
+             Ron Fox
+	     NSCL
+	     Michigan State University
+	     East Lansing, MI 48824-1321
+*/
+#include "CUnifiedFormatter.h"
+#include <RingItemFactoryBase.h>         // unified fmt
+#include <NSCLDAQFormatFactorySelector.h>  // unified fmt.
+#include <CRingItem.h>                    // unified fmt
+#include <DataFormat.h>                   // unified fmt.
+#include <stdexcept>
+#include <map>
+
+
+/// Data and static utilities -- with new major versions of NSCLDAQ
+/// This map needs to be extended.
+
+std::map<int, FormatSelector::SupportedVersions> versionMap = {
+    {10, FormatSelector::v10},
+    {11, FormatSelector::v11},
+    {12, FormatSelector::v12}
+};
+
+// This must be outside the class, again to avoid CRingItemConflicts:
+
+static CRingItem*
+makeActualItem(const CRingItem& raw, RingItemFactoryBase& fact) {
+    // the cases in the switch below will need to be expanded 
+    // as more ring item types are defined:
+
+    switch (raw.type()) {
+    case BEGIN_RUN:
+    case END_RUN:
+    case PAUSE_RUN:
+    case RESUME_RUN:
+        return fact.makeStateChangeItem(raw);
+    case ABNORMAL_ENDRUN:
+        return fact.makeAbnormalEndItem(raw);
+    case PACKET_TYPES:
+    case MONITORED_VARIABLES:
+        return fact.makeTextItem(raw);
+    case RING_FORMAT:
+        return fact.makeDataFormatItem(raw);
+    case PERIODIC_SCALERS:
+    case INCREMENTAL_SCALERS:
+    case TIMESTAMPED_NONINCR_SCALERS:
+        return fact.makeScalerItem(raw);
+    case PHYSICS_EVENT:
+        return fact.makePhysicsEventItem(raw);
+    case PHYSICS_EVENT_COUNT:
+        return fact.makePhysicsEventCountItem(raw);
+    case  EVB_FRAGMENT:
+        return fact.makeRingFragmentItem(raw);
+    case EVB_UNKNOWN_PAYLOAD:
+        return fact.makeUnknownFragment(raw);
+    case EVB_GLOM_INFO:
+        return fact.makeGlomParameters(raw);
+    }
+
+
+
+    return fact.makeRingItem(raw);
+}
+
+//// Implement UnifiedFormatter:
+
+/** constructor
+ *    Given the major version of NSCLDAQ - construct the appropriate
+ * RingItem factory so that we can create the appropriate actual ring items.
+ * and use their toString to format the item.
+ * 
+ * @param version - major version of NSCLDAQ the ring items belong to.
+ */
+CUnifiedFormatter::CUnifiedFormatter(int versions) : m_pFactory(0)
+{
+    auto p = versionMap.find(version);
+    if (p == versionMap.end()) {
+        // No such
+
+        throw std::invalid_argument("Not a valid formt selector in CUnifiedFormatter constructor");
+    }
+    m_pFactory = FormatSelector::selectFactory(p->second);
+}
+/**
+ * destructor
+ *  
+ */
+CUnifiedFormatter::~CUnifiedFormatter() {
+    delete m_pFactory;
+}
+
+/**
+ *  operator()
+ *     Given a pointer to a raw ring item formats returns
+ * a string representation for it.
+ * 
+ *  @param pItem - pointer to the raw ring item storage.
+ *  @return std::string - string representation of the ring item.
+ *  
+ */
+std::string
+CUnifiedFormatter::operator()(const void* pItem) {
+    const pRingItem pRaw = reinterpret_cast<const pRingitem>(pItem);
+
+    auto rawItem = m_pFactory->makeRingItem(pRaw);
+    auto actualItem = makeActualItem(*rawItem, *m_pFactory);
+
+    std::string result = actualItem->toString();
+
+    delete rawItem;
+    delete actualItme;
+
+
+    return result;
+
+}

--- a/main/utilities/bufdump/CUnifiedFormatter.cpp
+++ b/main/utilities/bufdump/CUnifiedFormatter.cpp
@@ -34,7 +34,7 @@
 
 #include <stdexcept>
 #include <map>
-
+using namespace ufmt;
 
 /// Data and static utilities -- with new major versions of NSCLDAQ
 /// This map needs to be extended.
@@ -48,7 +48,7 @@ std::map<int, FormatSelector::SupportedVersions> versionMap = {
 // This must be outside the class, again to avoid CRingItemConflicts:
 
 static CRingItem*
-makeActualItem(const CRingItem& raw, RingItemFactoryBase& fact) {
+makeActualItem(const CRingItem& raw, ::ufmt::RingItemFactoryBase& fact) {
     // the cases in the switch below will need to be expanded 
     // as more ring item types are defined:
 

--- a/main/utilities/bufdump/CUnifiedFormatter.h
+++ b/main/utilities/bufdump/CUnifiedFormatter.h
@@ -31,8 +31,10 @@
 
 
 
-class RingItemFactoryBase;
+namespace ufmt {
 
+    class RingItemFactoryBase;
+}
 /**
  * This class hides the use of the unified formatter in a separate library.
  * The idea is that the bufdumpmain can instantiate it and pass it ring item
@@ -41,7 +43,7 @@ class RingItemFactoryBase;
  */
 class CUnifiedFormatter {              // Final
 private:
-    RingItemFactoryBase* m_pFactory;
+    ufmt::RingItemFactoryBase* m_pFactory;
 public:
     CUnifiedFormatter(int version);
     ~CUnifiedFormatter();

--- a/main/utilities/bufdump/CUnifiedFormatter.h
+++ b/main/utilities/bufdump/CUnifiedFormatter.h
@@ -41,7 +41,7 @@ class RingItemFactoryBase;
  */
 class CUnifiedFormatter {              // Final
 private:
-    RingItemFactoryBase* m_pBase;
+    RingItemFactoryBase* m_pFactory;
 public:
     CUnifiedFormatter(int version);
     ~CUnifiedFormatter();

--- a/main/utilities/bufdump/CUnifiedFormatter.h
+++ b/main/utilities/bufdump/CUnifiedFormatter.h
@@ -1,0 +1,53 @@
+/*
+    This software is Copyright by the Board of Trustees of Michigan
+    State University (c) Copyright 2005.
+
+    You may use this software under the terms of the GNU public license
+    (GPL).  The terms of this license are described at:
+
+     http://www.gnu.org/licenses/gpl.txt
+
+     Author:
+             Ron Fox
+	     NSCL
+	     Michigan State University
+	     East Lansing, MI 48824-1321
+*/
+#ifndef UNIFIEDFORMATTER_H
+#define UNIFIEDFORMATTER_H
+/**
+ * @file CUnifiedFormater.h
+ * @brief Provides a mechanism to format ring items->strings using unifiedfmt
+ * 
+ * @note In order to prevent conflicts with the CRingItems in NSCLDAQ, we'll need to 
+ * isolate this in a library and build that library against the unified format--and hope
+ * the symbols are then weak enough to avoid collisions with CRingItem in NSCLDAQ and
+ * CRingItem in UnifiedFormat.
+ * 
+ *  
+*/
+
+#include <string>
+
+
+
+class RingItemFactoryBase;
+
+/**
+ * This class hides the use of the unified formatter in a separate library.
+ * The idea is that the bufdumpmain can instantiate it and pass it ring item
+ * data which will then be formatted via the appropriate underlying factory.
+ * 
+ */
+class CUnifiedFormatter {              // Final
+private:
+    RingItemFactoryBase* m_pBase;
+public:
+    CUnifiedFormatter(int version);
+    ~CUnifiedFormatter();
+
+    std::string operator()(const void* pItem);    // Avoid use of CRingItem to void conflicts.
+
+};
+
+#endif

--- a/main/utilities/bufdump/Makefile.am
+++ b/main/utilities/bufdump/Makefile.am
@@ -1,4 +1,5 @@
 bin_PROGRAMS	=	dumper
+lib_LTLIBRARIES    =   libStringifier.la
 
 
 dumper_SOURCES	=	BufdumpMain.cpp		\
@@ -32,6 +33,12 @@ dumper_LDADD		=	@top_builddir@/utilities/common/libUtilCommon.la 	\
 				@LIBEXCEPTION_LDFLAGS@				\
 				@top_builddir@/base/os/libdaqshm.la            \
 				$(THREADLD_FLAGS)
+
+
+libStringifier_la_SOURCES = CUnifiedFormatter.cpp CUnifiedFormatter.headers
+
+libStringifier_la_CPPFLAGS = @UFMT_CPPFLAGS@
+libStringifier_la_LIBADD = @UFMT_LDFLAGS@
 
 clean-local:
 	rm -f dumperargs.o $(BUILT_SOURCES)

--- a/main/utilities/bufdump/Makefile.am
+++ b/main/utilities/bufdump/Makefile.am
@@ -24,7 +24,8 @@ dumper_CPPFLAGS =	-I@srcdir@/.. 				\
 				-I@top_srcdir@/utilities/common \
 				@PIXIE_CPPFLAGS@
 
-dumper_LDADD		=	@top_builddir@/utilities/common/libUtilCommon.la 	\
+dumper_LDADD		=	 @builddir@/libStringifier.la \
+				@top_builddir@/utilities/common/libUtilCommon.la 	\
 				@top_builddir@/base/uri/liburl.la			\
                                 @top_builddir@/daq/IO/libdaqio.la			\
 				@top_builddir@/daq/format/libdataformat.la	\
@@ -33,12 +34,12 @@ dumper_LDADD		=	@top_builddir@/utilities/common/libUtilCommon.la 	\
 				@LIBEXCEPTION_LDFLAGS@				\
 				@top_builddir@/base/os/libdaqshm.la            \
 				$(THREADLD_FLAGS)
-
-
+dumper_DEPENDENCIES = libStringifier.la 
 libStringifier_la_SOURCES = CUnifiedFormatter.cpp CUnifiedFormatter.headers
 
 libStringifier_la_CPPFLAGS = @UFMT_CPPFLAGS@
 libStringifier_la_LIBADD = @UFMT_LDFLAGS@
+libStringifier_la_LDFLAGS = -static      #make this static too.
 
 clean-local:
 	rm -f dumperargs.o $(BUILT_SOURCES)

--- a/main/utilities/bufdump/Makefile.am
+++ b/main/utilities/bufdump/Makefile.am
@@ -39,7 +39,7 @@ libStringifier_la_SOURCES = CUnifiedFormatter.cpp CUnifiedFormatter.headers
 
 libStringifier_la_CPPFLAGS = @UFMT_CPPFLAGS@
 libStringifier_la_LIBADD = @UFMT_LDFLAGS@
-libStringifier_la_LDFLAGS = -static      #make this static too.
+
 
 clean-local:
 	rm -f dumperargs.o $(BUILT_SOURCES)

--- a/main/utilities/bufdump/dumper_man.xml
+++ b/main/utilities/bufdump/dumper_man.xml
@@ -154,6 +154,15 @@ dumper <replaceable>?options?</replaceable>
             </listitem>
         </varlistentry>
         <varlistentry>
+            <term><option>--nscldaq-version</option> <replaceable>10 | 11 | 12</replaceable></term>
+            <listitem>
+                <para>
+                    Specifies the version of NSCLDAQ the event file was written in.  
+                    Defaults to <literal>12</literal>
+                </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
             <term><option>--version</option></term>
             <listitem>
                 <para>

--- a/main/utilities/bufdump/dumperargs.ggo
+++ b/main/utilities/bufdump/dumperargs.ggo
@@ -8,4 +8,5 @@ option "count"  c "Number of items to dump before exiting" int optional
 option "sample" S "List of item types to sample" string optional
 option "exclude" e "List of item types to exclude from the dump" string optional
 option "scaler-width" w "Number of bits wide scaler counters are" int optional default="32"
+option "nscldaq-version" n "NSCLDAQ major version; 10, 11, or 12 e.g." int optional default="12"
 


### PR DESCRIPTION
Resolve issue #124 

* incorporate 2.0 of unified format (everything is in the ufmt or ufmt::_version_ namespace)
*  Use unified format in dumper to support a --nscldaq-version option.
* Port ddasdumper to version 2.0 of unified format.