### PR TITLE
Issue #221 - readout wizard set title/run don't work.

### DIFF
--- a/main/utilities/manager/mg_readout_wizard.tcl
+++ b/main/utilities/manager/mg_readout_wizard.tcl
@@ -1538,11 +1538,12 @@ proc ensureSequencesExist {db} {
 proc makeRunControlPrograms {dbcmd name parameters} {
 
     set kvparams $parameters
+    set readoutName ${name}_readout
     dict set kvparams name ${name}_readout
     makeRunControlProgram \
-        $dbcmd ${name}_settitle [file join \$DAQBIN rdo_titleFromKv] $kvparams [dict get $parameters name]
+        $dbcmd ${name}_settitle [file join \$DAQBIN rdo_titleFromKv] $kvparams $readoutName
     makeRunControlProgram \
-        $dbcmd ${name}_setrun [file join \$DAQBIN rdo_runFromKv] $kvparams [dict get $parameters name]
+        $dbcmd ${name}_setrun [file join \$DAQBIN rdo_runFromKv] $kvparams $readoutName
     makeRunControlProgram \
         $dbcmd ${name}_beginrun [file join \$DAQBIN rdo_control] $parameters begin
     makeRunControlProgram \


### PR DESCRIPTION
Fixed the program name parameter which missed the _readout suffix for the definition of those programs.
In /transition if attempting a transtion to the state we're already in, just return without trying.  This may also deal with cases when the transition is attempting from multiple sources simultaneously though it does 'allow' a generally disallowed transition.

resolves issue #221