### PR TITLE
Aschester/12.1 xiaapi4

### DIFF
--- a/main/configure.ac
+++ b/main/configure.ac
@@ -346,7 +346,7 @@ AC_CHECK_FILE([${srcdir}/libtcl/configure.ac],
 		[AC_MSG_NOTICE([Incorporating tcl++ for you])
 		${srcdir}/tcl++incorp])
 AC_MSG_NOTICE([Building and installing tcl++])
-(cd libtcl; ./configure --prefix=${prefix}; make clean && make -j ${incorp_cores} install)
+(cd libtcl; ./configure --prefix=${prefix}; make clean ; make -j ${incorp_cores} all ; make install)
 result=$?
 AS_VAR_IF([result], [0], [], AC_MSG_ERROR([Failed to build and install tcl++ with result: ${result}]))
 LIBTCLPLUS_CFLAGS="-I${prefix}/include"
@@ -365,7 +365,7 @@ tcl_configdir="/usr/lib/$tcl_basename"
 tcl_incdir="/usr/include/$tcl_basename"
 
 (cd ${srcdir}/tclhttpd3.5.1; ./configure --prefix=${prefix}/share/tclhttpd --enable-gcc --with-tclinclude=$tcl_incdir --with-tcl=$tcl_configdir)
-(cd ${srcdir}/tclhttpd3.5.1; make clean && make -j ${incorp_cores} install)
+(cd ${srcdir}/tclhttpd3.5.1; make clean ; make -j ${incorp_cores} all ; make install)
 
 # Epics
 #
@@ -413,7 +413,7 @@ AC_CHECK_FILE([${srcdir}/unifiedformat/CMakeLists.txt],
 rm -rf unifiedformat/build
 AS_MKDIR_P(unifiedformat/build)	
 AC_MSG_NOTICE([Building unified format])
-(cd unifiedformat/build; cmake .. -DCMAKE_INSTALL_PREFIX=${prefix}/unifiedformat; make clean; make -j ${incorp_cores} install)
+(cd unifiedformat/build; cmake .. -DCMAKE_INSTALL_PREFIX=${prefix}/unifiedformat; make clean; make -j ${incorp_cores} all ; make install)
 result=$?
 AS_VAR_IF([result], [0], [], AC_MSG_ERROR([Failed to build and install unified format library with result: ${result}]))
 UFMT_CPPFLAGS="-I${prefix}/unifiedformat/include"
@@ -433,7 +433,7 @@ AC_CHECK_FILE([${srcdir}/ddasformat/CMakeLists.txt],
 rm -rf ddasformat/build
 AS_MKDIR_P(ddasformat/build)
 AC_MSG_NOTICE([Building DDAS format])
-(cd ddasformat/build; cmake .. -DCMAKE_INSTALL_PREFIX=${prefix}/ddasformat; make clean; make -j ${incorp_cores} install)
+(cd ddasformat/build; cmake .. -DCMAKE_INSTALL_PREFIX=${prefix}/ddasformat; make clean; make -j ${incorp_cores} all ; make install)
 result=$?
 AS_VAR_IF([result], [0], [], AC_MSG_ERROR([Failed to build and install ddasformat with result: ${result}]))
 DDASFMT_CPPFLAGS="-I${prefix}/ddasformat/include"
@@ -917,6 +917,7 @@ Makefile
     ddas/ddasdumper/ddasdumper
     ddas/readout/Makefile
     ddas/readout/DDASFirmwareVersions.txt
+    ddas/readout/pixieserver.tcl
     ddas/pixieplugin/Makefile
     ddas/pixieplugin/definitions.tcl
     ddas/qtscope/Makefile

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.61)
 
-AC_INIT(nscldaq, 12.1-007, [daqhelp@nscl.msu.edu], [], [https://github.com/FRIBDAQ/NSCLDAQ])
+AC_INIT(nscldaq, 12.1-xiaapi4, [daqhelp@nscl.msu.edu], [], [https://github.com/FRIBDAQ/NSCLDAQ])
 
 AC_CONFIG_SRCDIR([/base/dataflow/CRingBuffer.h])
 AC_CONFIG_HEADER([config.h])

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.61)
 
-AC_INIT(nscldaq, 12.1-xiaapi4, [daqhelp@nscl.msu.edu], [], [https://github.com/FRIBDAQ/NSCLDAQ])
+AC_INIT(nscldaq, 12.1-007, [daqhelp@nscl.msu.edu], [], [https://github.com/FRIBDAQ/NSCLDAQ])
 
 AC_CONFIG_SRCDIR([/base/dataflow/CRingBuffer.h])
 AC_CONFIG_HEADER([config.h])

--- a/main/ddas/booter/SystemBooter.cpp
+++ b/main/ddas/booter/SystemBooter.cpp
@@ -48,7 +48,7 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 	std::cout << "---------------------------\n";
 	std::cout << "Initializing Pixie crate simulation... \n";
 	std::cout.flush();
-	int nModules = 4;
+	int nModules = 3;
 	int retval = Pixie16InitSystem(nModules, nullptr, 1);
 	if (retval < 0) {
 	    throw CXIAException("SystemBooter::boot() failed",
@@ -73,6 +73,7 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 				    "Pixie16BootModule()", retval);
 	    }
 	}
+
 	std::cout << "Crate simulation: all modules ok" << std::endl;
     } else {    
 	std::cout << "---------------------------\n";

--- a/main/ddas/booter/SystemBooter.cpp
+++ b/main/ddas/booter/SystemBooter.cpp
@@ -159,7 +159,7 @@ DAQ::DDAS::SystemBooter::bootModuleByIndex(
     int retval = Pixie16BootModule(
 	Pixie16_Com_FPGA_File, Pixie16_SP_FPGA_File, Pixie16_Trig_FPGA_File,
 	Pixie16_DSP_Code_File, DSPParFile, Pixie16_DSP_Var_File,
-        modIndex, computeBootMask(type)
+	modIndex, computeBootMask(type)
 	);
     if (retval < 0) {	
 	std::string msg = "Boot failed module " + std::to_string(modIndex);

--- a/main/ddas/booter/SystemBooter.cpp
+++ b/main/ddas/booter/SystemBooter.cpp
@@ -33,10 +33,15 @@ DAQ::DDAS::SystemBooter::SystemBooter() :
  * contains the firmware files for each hardware type, the slot map, and the 
  * number of modules. During the course of booting, the hardware will be 
  * queried as well to determine the the serial number, revision, ADC 
- * frequency, and resolution. The revision, adc frequency, and resolution 
+ * frequency, and resolution. The revision, ADC frequency, and resolution 
  * will all be parsed and the information will be stored in the configuration
  * as a HardwareRegistry::HardwareType.
-*/
+ *
+ * XIA's "offline mode" consists of an emulated crate containing, at the 
+ * moment, 4 modules of "common" type, including a 32-channel module in the 
+ * last slot. If offline mode is enabled, the crate simulation is started, 
+ * otherwise attempt to boot physical hardware.
+ */
 void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 {
     if (m_offlineMode) {
@@ -57,7 +62,7 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 
 	char parFile[FILENAME_STR_MAXLEN];
 	for (int i = 0; i < nModules; i++) {
-	    std::cout << "\nBooting simulation module #" << i << std::endl;
+	    std::cout << "\nBooting simulated module #" << i << std::endl;
 	    strcpy(parFile, config.getSettingsFilePath(i).c_str());
 	    retval = Pixie16BootModule("sys.bin", "fippi.bin", nullptr,
 				       "dsp.ldr", parFile, "dsp.var", i,
@@ -67,7 +72,7 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 				    "Pixie16BootModule()", retval);
 	    }
 	}
-	std::cout << "All modules ok " << std::endl;
+	std::cout << "Crate simulation: all modules ok" << std::endl;
     } else {    
 	std::cout << "---------------------------\n";
 	std::cout << "Initializing PXI access... \n";
@@ -82,7 +87,7 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 		"SystemBooter::boot() failed", "Pixie16InitSystem()", retval
 		);
 	} else {
-	    std::cout << "System initialized successfully. " << std::endl;
+	    std::cout << "System initialized successfully." << std::endl;
 	}
 
 	// Give the system some time to settle after initialization.
@@ -95,7 +100,7 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 	}
 
 	if (m_verbose) {
-	    std::cout << "All modules ok " << std::endl;
+	    std::cout << "All modules ok" << std::endl;
 	}
     }
 }

--- a/main/ddas/booter/SystemBooter.cpp
+++ b/main/ddas/booter/SystemBooter.cpp
@@ -17,7 +17,7 @@
 #include <Configuration.h>
 #include <CXIAException.h>
 
-const size_t FILENAME_STR_MAXLEN = 256;
+const size_t FILENAME_STR_MAXLEN = 256; //!< Max size of full path for FW.
 
 /**
  * @details

--- a/main/ddas/booter/SystemBooter.cpp
+++ b/main/ddas/booter/SystemBooter.cpp
@@ -17,6 +17,8 @@
 #include <Configuration.h>
 #include <CXIAException.h>
 
+const size_t FILENAME_STR_MAXLEN = 256;
+
 /**
  * @details
  * Enables verbose output by default.
@@ -37,35 +39,65 @@ DAQ::DDAS::SystemBooter::SystemBooter() :
 */
 void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 {
-    std::cout << "---------------------------\n";
-    std::cout << "Initializing PXI access... \n";
-    std::cout.flush();
+    if (m_offlineMode) {
+	std::cout << "---------------------------\n";
+	std::cout << "Initializing Pixie crate simulation... \n";
+	std::cout.flush();
+	int nModules = 4;
+	int retval = Pixie16InitSystem(nModules, nullptr, 1);
+	if (retval < 0) {
+	    throw CXIAException("SystemBooter::boot() failed",
+				"Pixie16InitSystem()", retval);
+	} else {
+	    std::cout << "Crate simulation initialized successfully."
+		      << std::endl;
+	}
 
-    int NumModules = config.getNumberOfModules();
-    int retval = Pixie16InitSystem(
-	NumModules, config.getSlotMap().data(), m_offlineMode
-	);
-    if (retval < 0) {
-	throw CXIAException(
-	    "SystemBooter::boot() failed", "Pixie16InitSystem()", retval
-	    );
-    } else {
-	std::cout << "System initialized successfully. " << std::endl;
-    }
+	populateHardwareMap(config);
 
-    // Give the system some time to settle after initialization.
-    usleep(1000);
-
-    populateHardwareMap(config);
-
-    for (int index = 0; index < NumModules; ++index) {
-	bootModuleByIndex(index, config, type);
-    }
-
-    if (m_verbose) {
+	char parFile[FILENAME_STR_MAXLEN];
+	for (int i = 0; i < nModules; i++) {
+	    std::cout << "\nBooting simulation module #" << i << std::endl;
+	    strcpy(parFile, config.getSettingsFilePath(i).c_str());
+	    retval = Pixie16BootModule("sys.bin", "fippi.bin", nullptr,
+				       "dsp.ldr", parFile, "dsp.var", i,
+				       computeBootMask(type));
+	    if (retval < 0) {
+		throw CXIAException("SystemBooter::boot() failed",
+				    "Pixie16BootModule()", retval);
+	    }
+	}
 	std::cout << "All modules ok " << std::endl;
-    }
+    } else {    
+	std::cout << "---------------------------\n";
+	std::cout << "Initializing PXI access... \n";
+	std::cout.flush();
 
+	int NumModules = config.getNumberOfModules();
+	int retval = Pixie16InitSystem(
+	    NumModules, config.getSlotMap().data(), 0
+	    );
+	if (retval < 0) {
+	    throw CXIAException(
+		"SystemBooter::boot() failed", "Pixie16InitSystem()", retval
+		);
+	} else {
+	    std::cout << "System initialized successfully. " << std::endl;
+	}
+
+	// Give the system some time to settle after initialization.
+	usleep(1000);
+
+	populateHardwareMap(config);
+
+	for (int index = 0; index < NumModules; ++index) {
+	    bootModuleByIndex(index, config, type);
+	}
+
+	if (m_verbose) {
+	    std::cout << "All modules ok " << std::endl;
+	}
+    }
 }
 
 /**
@@ -80,10 +112,9 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
  */
 void
 DAQ::DDAS::SystemBooter::bootModuleByIndex(
-    int modIndex, Configuration& m_config, BootType type
+    int modIndex, Configuration& config, BootType type
     )
 {
-    const size_t FILENAME_STR_MAXLEN = 256;
     char Pixie16_Com_FPGA_File[FILENAME_STR_MAXLEN];
     char Pixie16_SP_FPGA_File[FILENAME_STR_MAXLEN];
     char Pixie16_DSP_Code_File[FILENAME_STR_MAXLEN];
@@ -92,7 +123,7 @@ DAQ::DDAS::SystemBooter::bootModuleByIndex(
     char DSPParFile[FILENAME_STR_MAXLEN];
 
     // Select firmware and dsp files based on hardware variant
-    std::vector<int> hdwrMap = m_config.getHardwareMap();
+    std::vector<int> hdwrMap = config.getHardwareMap();
     if (hdwrMap[modIndex] == HardwareRegistry::Unknown) {
 	std::stringstream errmsg;
 	errmsg << "Cannot boot module " << modIndex
@@ -107,7 +138,7 @@ DAQ::DDAS::SystemBooter::bootModuleByIndex(
     // module firmware configuration which will default to the global config
     // if not specified.
     
-    FirmwareConfiguration fwConfig = m_config.getModuleFirmwareConfiguration(
+    FirmwareConfiguration fwConfig = config.getModuleFirmwareConfiguration(
 	hdwrMap[modIndex], modIndex
 	);
 
@@ -120,7 +151,7 @@ DAQ::DDAS::SystemBooter::bootModuleByIndex(
 
     // daqdev/DDAS#106 - modified as above to get a per module setfile:
     
-    strcpy(DSPParFile, m_config.getSettingsFilePath(modIndex).c_str());
+    strcpy(DSPParFile, config.getSettingsFilePath(modIndex).c_str());
 
     if (m_verbose) {
 	if (type == FullBoot) {

--- a/main/ddas/booter/SystemBooter.cpp
+++ b/main/ddas/booter/SystemBooter.cpp
@@ -58,11 +58,12 @@ void DAQ::DDAS::SystemBooter::boot(Configuration &config, BootType type)
 		      << std::endl;
 	}
 
+	config.setNumberOfModules(nModules);
 	populateHardwareMap(config);
 
 	char parFile[FILENAME_STR_MAXLEN];
 	for (int i = 0; i < nModules; i++) {
-	    std::cout << "\nBooting simulated module #" << i << std::endl;
+	    std::cout << "Booting simulated module #" << i << std::endl;
 	    strcpy(parFile, config.getSettingsFilePath(i).c_str());
 	    retval = Pixie16BootModule("sys.bin", "fippi.bin", nullptr,
 				       "dsp.ldr", parFile, "dsp.var", i,
@@ -238,35 +239,27 @@ void DAQ::DDAS::SystemBooter::populateHardwareMap(Configuration &config)
     unsigned int   ModSerNum;
     unsigned short ModADCBits;
     unsigned short ModADCMSPS;
-    unsigned short nchannels;
-
+    
     int NumModules = config.getNumberOfModules();
     std::vector<int> hdwrMapping(NumModules);
-
-    /** 
-     * @todo (ASC 12/14/23): For the API transition we want to read the 
-     * module_config struct. We may not even need to log it (just put them 
-     * in a vector) 
-     */
-    for(unsigned short i = 0; i < NumModules; i++) {
-	int retval = Pixie16ReadModuleInfo(
-	    i, &ModRev, &ModSerNum, &ModADCBits, &ModADCMSPS
-	    );
-	if (retval < 0)
-	{
-	    std::string msg = "Failed to read hardware variant module " + i;
-	    throw CXIAException(msg, "Pixie16ReadModuleInfo()", retval);
-	} else {
-	    if (m_verbose) {
-		logModuleInfo(i, ModRev, ModSerNum, ModADCBits, ModADCMSPS);
-	    }
-	    auto type = HardwareRegistry::computeHardwareType(
-		ModRev, ModADCMSPS, ModADCBits
-		);
-	    hdwrMapping[i] = type;
+    
+    for (unsigned short i = 0; i < NumModules; i++) {
+	module_config cfg;
+	int retval = PixieGetModuleInfo(i, &cfg);
+	if (retval < 0) {
+	    std::string msg = "Failed to read module info " + i;
+	    throw CXIAException(msg, "PixieGetModuleInfo()", retval);
 	}
+	if (m_verbose) {
+	    logModuleInfo(i, cfg.revision, cfg.serial_number,
+			  cfg.adc_bit_resolution, cfg.adc_sampling_frequency);
+	}
+	auto type = HardwareRegistry::computeHardwareType(
+	    cfg.revision, cfg.adc_sampling_frequency, cfg.adc_bit_resolution
+	    );
+	hdwrMapping[i] = type;
     }
-
+    
     // Store the hardware map in the configuration so other components of the
     // program can understand more about the hardware being used.
     config.setHardwareMap(hdwrMapping);
@@ -277,11 +270,10 @@ void DAQ::DDAS::SystemBooter::populateHardwareMap(Configuration &config)
 //
 
 /**
- * @todo (ASC 7/7/23): Lots of arguments to this function. Can we pack info 
- * into a struct and pass it around that way?
+ * @todo (ASC 7/7/23): Nice if this takes the config object or a pointer to it.
  */
 void DAQ::DDAS::SystemBooter::logModuleInfo(
-    int modIndex, unsigned short ModRev, unsigned short ModSerNum,
+    int modIndex, unsigned short ModRev, unsigned int ModSerNum,
     unsigned short ModADCBits, unsigned short ModADCMSPS
     )
 {

--- a/main/ddas/booter/SystemBooter.h
+++ b/main/ddas/booter/SystemBooter.h
@@ -144,7 +144,7 @@ namespace DAQ {
 	     * @param ModADCMSPS ADC frequency (MSPS).
 	     */
 	    void logModuleInfo(
-		int modIndex, unsigned short ModRev, unsigned short ModSerNum,
+		int modIndex, unsigned short ModRev, unsigned int ModSerNum,
 		unsigned short ModADCBits, unsigned short ModADCMSPS
 		);
 	    /**

--- a/main/ddas/booter/SystemBooter.h
+++ b/main/ddas/booter/SystemBooter.h
@@ -96,6 +96,17 @@ namespace DAQ {
 		int modIndex, Configuration& config, BootType type
 		);
 	    /**
+	     * @brief Boot a single module in offline mode.
+	     * @param modIndex Index of the module in the system.
+	     * @param m_config The system configuration.
+	     * @param type Boot style (load firmware or settings only).
+	     * @throw std::runtime_error If hardware type is unknown.
+	     * @throw CDDASException If Pixie16BootModule returns an error.
+	     */
+	    void bootModuleByIndexOffline(
+		int modIndex, Configuration& config, BootType type
+		);
+	    /**
 	     * @brief Enable or disable verbose output
 	     * @param enable Enables output messages if true.
 	     */

--- a/main/ddas/booter/SystemBooter.h
+++ b/main/ddas/booter/SystemBooter.h
@@ -72,13 +72,13 @@ namespace DAQ {
 	public:
 	    /** @brief Constructor. */
 	    SystemBooter();
-	    /*
-	     * @brief Boot the entire system.
+	    /**
+	     * @brief Boot the entire system with hardware.
 	     * @param config A configuration describing the system.
 	     * @param type Style of boot.
-	     * @throw CXIAException If Pixie16InitSystem() call returns 
+	     * @throw CXIAException If `Pixie16InitSystem()` call returns 
 	     *   an error.
-	     * @throw CXIAException If populateHardwareMap() throws.
+	     * @throw CXIAException If `populateHardwareMap()` throws.
 	     * @throw std::runtime_error If registered hardware is 
 	     *   unrecognized when attempting to boot.
 	     * @throws CXIAException If the Pixie boot fails.
@@ -90,20 +90,9 @@ namespace DAQ {
 	     * @param m_config The system configuration.
 	     * @param type Boot style (load firmware or settings only).
 	     * @throw std::runtime_error If hardware type is unknown.
-	     * @throw CDDASException If Pixie16BootModule returns an error.
+	     * @throw CDDASException If `Pixie16BootModule()` returns an error.
 	     */
 	    void bootModuleByIndex(
-		int modIndex, Configuration& config, BootType type
-		);
-	    /**
-	     * @brief Boot a single module in offline mode.
-	     * @param modIndex Index of the module in the system.
-	     * @param m_config The system configuration.
-	     * @param type Boot style (load firmware or settings only).
-	     * @throw std::runtime_error If hardware type is unknown.
-	     * @throw CDDASException If Pixie16BootModule returns an error.
-	     */
-	    void bootModuleByIndexOffline(
 		int modIndex, Configuration& config, BootType type
 		);
 	    /**
@@ -131,14 +120,16 @@ namespace DAQ {
 	     * @brief Read and store hardware info from each of the modules 
 	     * in the system.
 	     * @param config The system configuration.
-	     * @throw CDDASException If Pixie16ReadModuleInfo returns an error.
+	     * @throw CDDASException If `Pixie16ReadModuleInfo()` returns 
+	     *   an error.
 	     */
 	    void populateHardwareMap(Configuration &config);
 	    
 	private:
 	    /**
 	     * @brief Convert BootType enumeration to usable boot mask.
-	     * @param type Either BootType::FullBoot or BootType::SettingsOnly.
+	     * @param type Either `BootType::FullBoot` or 
+	     *   `BootType::SettingsOnly`.
 	     * @return unsigned int  
 	     * @retval 0x7f FullBoot
 	     * @retval 0x70 SettingsOnly.

--- a/main/ddas/configuration/Configuration.h
+++ b/main/ddas/configuration/Configuration.h
@@ -87,7 +87,7 @@ namespace DAQ {
 	    FirmwareMap m_fwMap; //!< Map of firmware for hardware types.
 	    std::vector<int> m_hardwareMap; //!< Map of HardwareRegistry types.
     
-	    // These additions support per module firmware maps and .set files:
+	    // These additions support per module firmware maps and set files:
 
 	    /** Per-module firmware maps */
 	    std::map<int, FirmwareMap> m_moduleFirmwareMaps;

--- a/main/ddas/configuration/HardwareRegistry.cpp
+++ b/main/ddas/configuration/HardwareRegistry.cpp
@@ -44,6 +44,7 @@ setUpRegistry(Registry& registry) {
     registry[HR::RevF_500MHz_12Bit] = {500, 12, 15, 10. };
     registry[HR::RevF_500MHz_14Bit] = {500, 14, 15, 10. };
     registry[HR::RevF_500MHz_16Bit] = {500, 16, 15, 10. };
+    registry[HR::RevH_250MHz_14Bit] = {250, 14, 17, 8. };
 }
 
 // Create a new registry and set default values

--- a/main/ddas/configuration/HardwareRegistry.h
+++ b/main/ddas/configuration/HardwareRegistry.h
@@ -84,6 +84,7 @@ namespace DAQ {
 		RevF_500MHz_12Bit=9,
 		RevF_500MHz_14Bit=10,
 		RevF_500MHz_16Bit=11,
+		RevH_250MHz_14Bit=12,
 		Unknown=0
 	    };
 

--- a/main/ddas/ddasdumper/Makefile.am
+++ b/main/ddas/ddasdumper/Makefile.am
@@ -1,14 +1,9 @@
 bin_PROGRAMS = ddasdumper.bin
 lib_LTLIBRARIES = libddasrootformat.la
-
-
-BUILT_SOURCES = ddasrootformatDictionary.h ddasrootformatDictionary.cpp \
-	ddasrootformatDictionary_rdict.pcm dumperargs.cpp
 include_HEADERS = DDASRootEvent.h DDASRootHit.h
 
 
-ddasdumper_bin_SOURCES = ddasdumper.cpp 				\
-	dumperargs.cpp dumperargs.h 					\
+ddasdumper_bin_SOURCES = dumperargs.cpp dumperargs.h ddasdumper.cpp 	\
 	DataSource.cpp DataSource.h					\
 	FdDataSource.cpp FdDataSource.h					\
 	StreamDataSource.cpp StreamDataSource.h				\
@@ -22,15 +17,14 @@ ddasdumper_bin_LDADD = @builddir@/libddasrootformat.la 			\
 	@top_builddir@/base/uri/liburl.la				\
 	@top_builddir@/daq/IO/libdaqio.la				
 ddasdumper_bin_LDFLAGS = @UFMT_LDFLAGS@ @DDASFMT_LDFLAGS@               \
-	@LIBEXCEPTION_LDFLAGS@ @ROOT_LDFLAGS@ 
+	@LIBEXCEPTION_LDFLAGS@ @ROOT_LDFLAGS@
 
 
 libddasrootformat_la_SOURCES = DDASRootEvent.cpp DDASRootHit.h LinkDef.h
 libddasrootformat_la_CPPFLAGS = -I@top_srcdir@ @DDASFMT_CPPFLAGS@ @ROOT_CFLAGS@
 libddasrootformat_la_LIBADD = @DDASFMT_LDFLAGS@
-libddasrootformat_la_LDFLAGS = @ROOT_LDFLAGS@ 
-nodist_libddasrootformat_la_SOURCES = \
-	ddasrootformatDictionary.cpp ddasrootformatDictionary.h
+libddasrootformat_la_LDFLAGS = @ROOT_LDFLAGS@
+nodist_libddasrootformat_la_SOURCES = ddasrootformatDictionary.cpp ddasrootformatDictionary.h
 
 
 dumperargs.cpp: dumperargs.h
@@ -59,3 +53,4 @@ clean-local:
 
 
 EXTRA_DIST = ddasdumper.in dumperargs.ggo ddasdumper.dox
+

--- a/main/ddas/pixieplugin/definitions.tcl.in
+++ b/main/ddas/pixieplugin/definitions.tcl.in
@@ -37,5 +37,4 @@ exec tclsh "$0" ${1+"$@"}
 # associated with this NSCLDAQ build in using autoconf:
 #
 
-set DDAS_INSTDIR @DDAS_INSTDIR@
-set DAQ_INSTDIR @prefix
+set DAQ_INSTDIR @prefix@

--- a/main/ddas/pixieplugin/pixieplugin.tcl
+++ b/main/ddas/pixieplugin/pixieplugin.tcl
@@ -37,13 +37,12 @@ source [file join $here definitions.tcl]
 #
 #  Add the TclLibs for NSCLDAQ and DDAS to the auto search path then
 #  we can require the port manager and pixieserver packages.
-#  @note this directory must havea a pxisys.ini and cfgPixie16.txt file.
+#  @note this directory must have a cfgPixie16.txt file.
 #         else the pixieserver package will fail to load.
 #
-set DDASTclPackages [file join $DDAS_INSTDIR TclLibs]
 set DAQTclPackages  [file join $DAQ_INSTDIR TclLibs]
 
-lappend auto_path $DDASTclPackages $DAQTclPackages
+lappend auto_path $DAQTclPackages
 package require removetcllibpath
 package require pixieserver
 package require portAllocator

--- a/main/ddas/pixieplugin/plugindocs.xml
+++ b/main/ddas/pixieplugin/plugindocs.xml
@@ -7,7 +7,7 @@
    </refmeta>
    <refnamediv>
       <refname>pixieplugin</refname>
-      <refpurpose>Suport dynamic configuration of Pixie16 modules via DDASReadout Server.</refpurpose>
+      <refpurpose>Support dynamic configuration of Pixie-16 modules via DDASReadout Server.</refpurpose>
     </refnamediv>
     <refsynopsisdiv>
         <synopsis>
@@ -475,18 +475,6 @@ Successful reply:
             of the Tcl intepreter at the time the plugin package is loaded:
         </para>
         <variablelist>
-            <varlistentry>
-               <term><filename>pxisys.ini</filename></term>
-               <listitem>
-                   <para>
-                    A file that describes the slot mapping in terms of the PCI
-                    resources on the PXI backplane.  The contents of this file
-                    depend on the vendor that produced the backplane. We currently
-                    have versions of this file for several crate types stored in
-                    <filename>$DDAS_ROOT/share/crateconfigs</filename>.
-                   </para>
-                </listitem>
-            </varlistentry>
             <varlistentry>
                <term><filename>cfgPixie16.txt</filename></term>
                <listitem>

--- a/main/ddas/qtscope/CDataGenerator.cpp
+++ b/main/ddas/qtscope/CDataGenerator.cpp
@@ -8,13 +8,15 @@
 #include <iostream>
 #include <cmath>
 
-std::mt19937 CDataGenerator::m_engine(std::random_device{}());
-std::uniform_real_distribution<double> CDataGenerator::m_C(1000, 2000);
-std::uniform_real_distribution<double> CDataGenerator::m_A(100, 10000);
-std::normal_distribution<double> CDataGenerator::m_rise(0.5, 0.05);
-std::normal_distribution<double> CDataGenerator::m_decay(5, 0.05);
-std::uniform_real_distribution<double> CDataGenerator::m_baseline(4500, 5500);
-std::normal_distribution<double> CDataGenerator::m_noise(0, 10);
+/**
+ * @details
+ * Create all distributions that are independent of the data size.
+ */
+CDataGenerator::CDataGenerator() :
+    m_engine(std::random_device{}()),  m_C(1000, 2000), m_A(100, 10000),
+    m_rise(0.5, 0.05), m_decay(5.0, 0.05), m_baseline(4500, 5500),
+    m_noise(0, 10)
+{}
 
 /**
  * @details

--- a/main/ddas/qtscope/CDataGenerator.cpp
+++ b/main/ddas/qtscope/CDataGenerator.cpp
@@ -8,6 +8,14 @@
 #include <iostream>
 #include <cmath>
 
+std::mt19937 CDataGenerator::m_engine(std::random_device{}());
+std::uniform_real_distribution<double> CDataGenerator::m_C(1000, 2000);
+std::uniform_real_distribution<double> CDataGenerator::m_A(100, 10000);
+std::normal_distribution<double> CDataGenerator::m_rise(0.5, 0.05);
+std::normal_distribution<double> CDataGenerator::m_decay(5, 0.05);
+std::uniform_real_distribution<double> CDataGenerator::m_baseline(4500, 5500);
+std::normal_distribution<double> CDataGenerator::m_noise(0, 10);
+
 /**
  * @details
  * Params are a pointer to the start of the data storage and a size, as is 
@@ -18,20 +26,17 @@ CDataGenerator::GetTraceData(
     unsigned short* data, int dataSize, double binWidth
     )
 {
-    std::uniform_real_distribution<double> C(1000, 2000);
-    std::uniform_real_distribution<double> A(100, 10000);
-    std::uniform_real_distribution<double> t0(0.05*dataSize, 0.95*dataSize);
-    std::normal_distribution<double> rise(0.5, 0.05);
-    std::normal_distribution<double> decay(5, 0.05);
+    // Depends on dataSize, must be local:
+    std::uniform_real_distribution<double> dt0(0.05*dataSize, 0.95*dataSize);
+    
+    double C = m_C(m_engine);         // ADC units.
+    double A = m_A(m_engine);         // ADC units.
+    double t0 = dt0(m_engine);       // Sample number.
+    double rise = m_rise(m_engine);   // Microseconds.
+    double decay = m_decay(m_engine); // Microseconds.
 
-    double myC = C(m_engine);         // ADC units.
-    double myA = A(m_engine);         // ADC units.
-    double myT0 = t0(m_engine);       // Sample number.
-    double myRise = rise(m_engine);   // Microseconds.
-    double myDecay = decay(m_engine); // Microseconds.
-  
     for (int i = 0; i < dataSize; i++) {
-	data[i] = SinglePulse(myC, myA, myT0, myRise, myDecay, i, binWidth);
+	data[i] = SinglePulse(C, A, t0, rise, decay, i, binWidth);
     }
   
     return 0;
@@ -46,10 +51,12 @@ CDataGenerator::GetTraceData(
 int
 CDataGenerator::GetHistogramData(unsigned int* data, int dataSize)
 {
-    std::normal_distribution<double> gaus(dataSize/4, 10); // Mean, stddev.    
+    // Depends on dataSize, must be local:
+    std::normal_distribution<double> dgaus(dataSize/4, 10); // Mean, stddev.    
     int ene = 0; // Event energy.
+    
     for (int i = 0; i < 10000; i++) {
-	ene = static_cast<unsigned int>(gaus(m_engine));
+	ene = static_cast<unsigned int>(dgaus(m_engine));
 	data[ene]++;	
     }  
 
@@ -63,10 +70,9 @@ CDataGenerator::GetHistogramData(unsigned int* data, int dataSize)
  */
 int
 CDataGenerator::GetBaselineData(double* data, int dataSize)
-{
-    std::uniform_real_distribution<double> dist(4500, 5500); // range
+{    
     for (int i = 0; i < dataSize; i++) {
-	data[i] = dist(m_engine);
+	data[i] = m_baseline(m_engine);
     }
 
     return 0;  
@@ -82,15 +88,13 @@ CDataGenerator::SinglePulse(
     // channel parameter value:
   
     double dt = (sample - t0)*binWidth;
-  
-    std::normal_distribution<double> noise(0, 10); // Mean, stddev.
-    unsigned short pval = 0;  
+    unsigned short pval = 0; // Pulse value for current sample
   
     if (sample < t0) {
-	pval =  static_cast<unsigned short>(C + noise(m_engine));
+	pval =  static_cast<unsigned short>(C + m_noise(m_engine));
     } else {
 	pval =  static_cast<unsigned short>(
-	    C + A*(1-std::exp(-dt/rise))*std::exp(-dt/decay) + noise(m_engine)
+	    C + A*(1-std::exp(-dt/rise))*std::exp(-dt/decay) + m_noise(m_engine)
 	    );
     }
 

--- a/main/ddas/qtscope/CDataGenerator.h
+++ b/main/ddas/qtscope/CDataGenerator.h
@@ -31,12 +31,19 @@
 class CDataGenerator
 {
 private:
-    std::mt19937 m_engine; //!< Random number generator engine.
+    // Previous 12.x versions had the engine as a non-static member.
+    // I cannot quite figure out why but initialization of non-static
+    // engine fails and the program hangs when generating random numbers.
+    // Possibly related to threading??? Anyway, this works:
+    static std::mt19937 m_engine; //!< Random number generator engine.
+    static std::uniform_real_distribution<double> m_C; //!< Trace offset.
+    static std::uniform_real_distribution<double> m_A; //!< Trace amplitude.
+    static std::normal_distribution<double> m_rise; //!< Trace exp. rise.
+    static std::normal_distribution<double> m_decay; //!< Trace exp. decay.
+    static std::normal_distribution<double> m_noise; //!< Trace noise.
+    static std::uniform_real_distribution<double> m_baseline; //!< Baseline run.
     
-public:
-    /** @brief Constructor. */
-    CDataGenerator() : m_engine((std::random_device())()) {};
-
+public:   
     /**
      * @brief Generate test trace data.
      * @param[in,out] data Pointer to the start of the trace data storage.
@@ -63,6 +70,7 @@ public:
     int GetBaselineData(double* data, int dataSize);
   
 private:
+    
     /**
      * @brief Analytical function for a single pulse with exponential rise and 
      * decay constants.

--- a/main/ddas/qtscope/CDataGenerator.h
+++ b/main/ddas/qtscope/CDataGenerator.h
@@ -31,19 +31,18 @@
 class CDataGenerator
 {
 private:
-    // Previous 12.x versions had the engine as a non-static member.
-    // I cannot quite figure out why but initialization of non-static
-    // engine fails and the program hangs when generating random numbers.
-    // Possibly related to threading??? Anyway, this works:
-    static std::mt19937 m_engine; //!< Random number generator engine.
-    static std::uniform_real_distribution<double> m_C; //!< Trace offset.
-    static std::uniform_real_distribution<double> m_A; //!< Trace amplitude.
-    static std::normal_distribution<double> m_rise; //!< Trace exp. rise.
-    static std::normal_distribution<double> m_decay; //!< Trace exp. decay.
-    static std::normal_distribution<double> m_noise; //!< Trace noise.
-    static std::uniform_real_distribution<double> m_baseline; //!< Baseline run.
+    std::mt19937 m_engine; //!< Random number generator engine.
+    std::uniform_real_distribution<double> m_C; //!< Trace offset.
+    std::uniform_real_distribution<double> m_A; //!< Trace amplitude.
+    std::normal_distribution<double> m_rise; //!< Trace exponential rise.
+    std::normal_distribution<double> m_decay; //!< Trace exponential decay.
+    std::normal_distribution<double> m_noise; //!< Trace random noise.
+    std::uniform_real_distribution<double> m_baseline; //!< Baseline run data.
     
-public:   
+public:
+    /** @brief Constructor. */
+    CDataGenerator();
+    
     /**
      * @brief Generate test trace data.
      * @param[in,out] data Pointer to the start of the trace data storage.

--- a/main/ddas/qtscope/CPixieRunUtilities.cpp
+++ b/main/ddas/qtscope/CPixieRunUtilities.cpp
@@ -32,8 +32,18 @@ CPixieRunUtilities::CPixieRunUtilities() :
 	16, std::vector<unsigned int>(MAX_HISTOGRAM_LENGTH, 0)
 	),
     m_runActive(false),
-    m_useGenerator(false)
+    m_useGenerator(false),
+    m_pGenerator(new CDataGenerator)
 {}
+
+/**
+ * @details
+ * Destroy the data generator object we're managing.
+ */
+CPixieRunUtilities::~CPixieRunUtilities()
+{
+    delete m_pGenerator;
+}
 
 /**
  * @todo Disable multiple modules from running in non-sync mode.
@@ -46,15 +56,14 @@ CPixieRunUtilities::BeginHistogramRun(int module)
     for (auto& v : m_genHistograms) {
 	std::fill(v.begin(), v.end(), 0);
     }
-
-    int retval;
+    
+    int retval;    
     try {
 	// Set the "infinite" run time of 99999 seconds:  
 	std::string paramName = "HOST_RT_PRESET";
 	retval = Pixie16WriteSglModPar(
 	    paramName.c_str(), Decimal2IEEEFloating(99999), module
-	    );
-  
+	    );  
 	if (retval < 0) {
 	    std::stringstream msg;
 	    msg << "Run time not properly set."
@@ -66,8 +75,7 @@ CPixieRunUtilities::BeginHistogramRun(int module)
 	// If the run time is properly set, begin a histogram run for this
 	// module turn off synchronization (0):  
 	paramName = "SYNCH_WAIT";
-	retval = Pixie16WriteSglModPar(paramName.c_str(), 0, module);
-  
+	retval = Pixie16WriteSglModPar(paramName.c_str(), 0, module);  
 	if (retval < 0) {
 	    std::stringstream msg;
 	    msg << "CPixieRunUtilities::BeginHistogramRun() failed to write "
@@ -153,7 +161,7 @@ CPixieRunUtilities::EndHistogramRun(int module)
 	std::cout << "Ended histogram run in Mod. " << module << std::endl;
 	m_runActive = false;
     }
-  
+    
     return 0;
 }
 
@@ -161,17 +169,18 @@ CPixieRunUtilities::EndHistogramRun(int module)
  * @details
  * Histogram data comes either from the module itself if running in online
  * mode or from the data generator.
+ * @note The data generator is primarily used to debug plot elements, curve 
+ * fitting and display options. It will ignore any histogram settings (EMin, 
+ * BinFactor) from the DSP.
  */
 int
 CPixieRunUtilities::ReadHistogram(int module, int channel)
 {
     // Allocate data structure for histogram and grab it or use the generator:
-  
     int retval;
     try {
 	if (m_useGenerator) {
-	    CDataGenerator gen;
-	    retval = gen.GetHistogramData(
+	    retval = m_pGenerator->GetHistogramData(
 		m_genHistograms[channel].data(), MAX_HISTOGRAM_LENGTH
 		);
 	    m_histogram = m_genHistograms[channel];
@@ -360,8 +369,8 @@ CPixieRunUtilities::UpdateBaselineHistograms(int module)
 	// Allocate data structure for baselines and grab them or use the
 	// data generator to get data for testing:    
 	if (m_useGenerator) {
-	    CDataGenerator gen;
-	    retval = gen.GetBaselineData(baselines.data(), MAX_NUM_BASELINES);
+	    retval = m_pGenerator->GetBaselineData(baselines.data(),
+						   MAX_NUM_BASELINES);
      
 	} else {
 	    retval = Pixie16ReadSglChanBaselines(

--- a/main/ddas/qtscope/CPixieRunUtilities.h
+++ b/main/ddas/qtscope/CPixieRunUtilities.h
@@ -9,6 +9,8 @@
 
 #include <vector>
 
+class CDataGenerator;
+
 /**
  * @addtogroup utilities libPixieUtilities.so
  * @{ 
@@ -34,10 +36,13 @@ private:
     std::vector<std::vector<unsigned int>> m_genHistograms;
     bool m_runActive;    //!< True when running.
     bool m_useGenerator; //!< True to use generator test data.
+    CDataGenerator* m_pGenerator; //!< Generator for synthetic data.
     
 public:
     /** @brief Constructor. */
     CPixieRunUtilities();
+    /** @brief Destructor. */
+    ~CPixieRunUtilities();
 
     /**
      * @brief Begin a histogram (MCA) run for a single module. Explicitly sets 

--- a/main/ddas/qtscope/CPixieSystemUtilities.cpp
+++ b/main/ddas/qtscope/CPixieSystemUtilities.cpp
@@ -91,10 +91,7 @@ CPixieSystemUtilities::Boot()
 	return -1;
     }
 
-    m_bootMode ? m_numModules = 4 : m_numModules
-	= m_config.getNumberOfModules();
-       
-    //m_numModules = m_config.getNumberOfModules();
+    m_numModules = m_config.getNumberOfModules();
     m_modEvtLength = m_config.getModuleEventLengths();
     
     // The hardware map is set up during boot time:

--- a/main/ddas/qtscope/CPixieSystemUtilities.cpp
+++ b/main/ddas/qtscope/CPixieSystemUtilities.cpp
@@ -91,11 +91,12 @@ CPixieSystemUtilities::Boot()
 	return -1;
     }
 
-    // Get number of modules and set event lengths based on modevtlen file:
-    
-    m_numModules = m_config.getNumberOfModules();
+    m_bootMode ? m_numModules = 4 : m_numModules
+	= m_config.getNumberOfModules();
+       
+    //m_numModules = m_config.getNumberOfModules();
     m_modEvtLength = m_config.getModuleEventLengths();
-  
+    
     // The hardware map is set up during boot time:
     
     std::vector<int> hdwrMap = m_config.getHardwareMap();
@@ -106,9 +107,9 @@ CPixieSystemUtilities::Boot()
 	m_modRev.push_back(spec.s_hdwrRevision);
 	m_modClockCal.push_back(spec.s_clockCalibration);
     }
-  
+
     m_booted = true;
-  
+
     return 0;
 }
 

--- a/main/ddas/qtscope/CPixieTraceUtilities.cpp
+++ b/main/ddas/qtscope/CPixieTraceUtilities.cpp
@@ -130,11 +130,11 @@ CPixieTraceUtilities::AcquireADCTrace(int module, int channel)
 	throw CXIAException(msg.str(), "Pixie16AcquireADCTrace()", retval);
     }
 
+    unsigned int len;
+    PixieGetTraceLength(module, channel, &len);
+    ResetTrace(len);
+    
     if (!m_useGenerator) {
-	unsigned int len;
-	PixieGetTraceLength(module, channel, &len);
-	ResetTrace(len);
-
 	retval = Pixie16ReadSglChanADCTrace(
 	    m_trace.data(), len, module, channel
 	    );
@@ -147,8 +147,33 @@ CPixieTraceUtilities::AcquireADCTrace(int module, int channel)
 		);
 	}
     } else {
-	std::cerr << "Offline data generation using the generator is not"
-		  << " supported for XIA API 3+" << std::endl;
+	// Get the trace binning and if successful generate a pulse:      
+	const char* pXDT = "XDT";
+	double xdt = 0;
+	retval = Pixie16ReadSglChanPar(pXDT, &xdt, module, channel);
+
+	if (retval < 0) {
+	    std::stringstream errmsg;
+	    errmsg << "CPixieTraceUtilities::AcquireADCTrace() failed";
+	    errmsg << " to read parameter " << pXDT
+		   << " from module " << module
+		   << " channel " << channel
+		   << " with retval " << retval;
+	    throw std::runtime_error(errmsg.str());
+	}
+
+	retval = m_pGenerator->GetTraceData(
+	    m_trace.data(), MAX_ADC_TRACE_LEN, xdt
+	    );
+
+	if (retval < 0) {
+	    std::stringstream errmsg;
+	    errmsg << "CPixieTraceUtilities::AcquireADCTrace() failed";
+	    errmsg << "to read trace from module " << module
+		   << " channel " << channel
+		   << " with retval " << retval;
+	    throw std::runtime_error(errmsg.str());
+	}
     }
 }
 

--- a/main/ddas/qtscope/CPixieTraceUtilities.cpp
+++ b/main/ddas/qtscope/CPixieTraceUtilities.cpp
@@ -23,8 +23,18 @@
  */
 CPixieTraceUtilities::CPixieTraceUtilities() :
     m_useGenerator(false),
-    m_validAmplitude(20)
+    m_validAmplitude(20),
+    m_pGenerator(new CDataGenerator)
 {}
+
+/**
+ * @details
+ * Destroy the data generator object we're managing.
+ */
+CPixieTraceUtilities::~CPixieTraceUtilities()
+{
+    delete m_pGenerator;
+}
 
 /**
  * @details

--- a/main/ddas/qtscope/CPixieTraceUtilities.h
+++ b/main/ddas/qtscope/CPixieTraceUtilities.h
@@ -9,6 +9,8 @@
 
 #include <vector>
 
+class CDataGenerator;
+
 /**
  * @addtogroup utilities libPixieUtilities.so
  * @{ 
@@ -30,6 +32,7 @@
 class CPixieTraceUtilities
 {
 private:
+    CDataGenerator* m_pGenerator; //!< The offline data generator.
     bool m_useGenerator; //!< True if using generated data, else online data.
     std::vector<unsigned short> m_trace; //!< Single channel trace data.
     double m_validAmplitude; //!< Minimum amplitude for a validated trace.

--- a/main/ddas/qtscope/CPixieTraceUtilities.h
+++ b/main/ddas/qtscope/CPixieTraceUtilities.h
@@ -40,6 +40,8 @@ private:
 public:
     /** @brief Constructor. */
     CPixieTraceUtilities();
+    /** @brief Destructor. */
+    ~CPixieTraceUtilities();
     
     /**
      * @brief Read a validated ADC trace from single channel.

--- a/main/ddas/qtscope/acquisition_toolbar.py
+++ b/main/ddas/qtscope/acquisition_toolbar.py
@@ -23,9 +23,6 @@ class AcquisitionToolBar(QToolBar):
         Button to begin and end runs.
     run_type : QComboBox
         Selection box for run type, list-mode histogram or baseline.
-    binning : QComboBox
-        Selection box for histogram binning. N ADC units/bin where N is the 
-        value displayed in this box.
     current_mod : QSpinBox 
         Module selection for acquisition.
     current_chan : QSpinBox 
@@ -78,10 +75,6 @@ class AcquisitionToolBar(QToolBar):
         self.b_run_control = QPushButton("Begin run")
         self.b_run_control.setStyleSheet(colors.CYAN)
 
-        self.binning = QComboBox()
-        self.binning.insertItems(0, ["1", "2", "4", "8", "16"])
-        label = QLabel("ADC units/bin")
-        
         self.run_type = QComboBox()
         self.run_type.insertItem(RunType.HISTOGRAM.value, "Energy hist.")
         self.run_type.insertItem(RunType.BASELINE.value, "Baseline")
@@ -89,8 +82,6 @@ class AcquisitionToolBar(QToolBar):
         run_control_layout.addWidget(self.b_read_data)
         run_control_layout.addWidget(self.b_run_control)
         run_control_layout.addWidget(self.run_type)
-        run_control_layout.addWidget(self.binning)
-        run_control_layout.addWidget(label)
         
         run_control_box.setLayout(run_control_layout)
 

--- a/main/ddas/qtscope/adc_trace.py
+++ b/main/ddas/qtscope/adc_trace.py
@@ -8,8 +8,8 @@ else:
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QCheckBox, QWidget, QHBoxLayout
 
-import xia_constants as xia
 from chan_dsp_widget import ChanDSPWidget
+import xia_constants as xia
 
 class Trace(ChanDSPWidget):
     """Trace DSP tab (ChanDSPWidget)."""

--- a/main/ddas/qtscope/analog_signal.py
+++ b/main/ddas/qtscope/analog_signal.py
@@ -1,11 +1,10 @@
-import numpy as np
-
 import bitarray as ba
 ver = [int(i) for i in ba.__version__.split(".")]
 if bool(ver[0] >= 1 or (ver[0] == 1 and ver[1] >= 6)):
     from bitarray.util import ba2int, int2ba
 else:
     from converters import ba2int, int2ba
+import numpy as np
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QDoubleValidator

--- a/main/ddas/qtscope/cfd.py
+++ b/main/ddas/qtscope/cfd.py
@@ -15,7 +15,7 @@ class CFD(ChanDSPWidget):
         Configure the CFD display. Overridden from the base class.
     display_dsp(mgr, mod) 
         Display DSP settings from the dataframe. Overridden from base class.
-    """    
+    """
     def __init__(self, *args, **kwargs):
         """CFD class constructor."""
         

--- a/main/ddas/qtscope/chan_dsp_gui.py
+++ b/main/ddas/qtscope/chan_dsp_gui.py
@@ -1,6 +1,6 @@
 import inspect
-import os
 import logging
+import os
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QCloseEvent, QPixmap

--- a/main/ddas/qtscope/chan_dsp_layout.py
+++ b/main/ddas/qtscope/chan_dsp_layout.py
@@ -34,7 +34,8 @@ class ChanDSPLayout(QTabWidget):
             "CSRA",
             "Baseline",
             "MultCoincidence",
-            "TimingControl"
+            "TimingControl",
+            "Histogram"
         ]
 
         # Define layout:

--- a/main/ddas/qtscope/chan_dsp_widget.py
+++ b/main/ddas/qtscope/chan_dsp_widget.py
@@ -1,5 +1,6 @@
-import numpy as np
 import logging
+
+import numpy as np
 
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import (

--- a/main/ddas/qtscope/converters.py
+++ b/main/ddas/qtscope/converters.py
@@ -1,5 +1,6 @@
-import sys
 from ctypes import create_string_buffer
+import sys
+
 from bitarray import bitarray, bits2bytes
 
 """

--- a/main/ddas/qtscope/dsp_manager.py
+++ b/main/ddas/qtscope/dsp_manager.py
@@ -1,6 +1,7 @@
-import logging
-import pandas as pd
 import inspect
+import logging
+
+import pandas as pd
 
 from pixie_utilities import DSPUtilities
 import xia_constants as xia

--- a/main/ddas/qtscope/fit_exp_creator.py
+++ b/main/ddas/qtscope/fit_exp_creator.py
@@ -1,5 +1,6 @@
-from fit_function import FitFunction
 import numpy as np
+
+from fit_function import FitFunction
 
 class ExpFit(FitFunction):
     """Exponential fitting function class used by QtScope.

--- a/main/ddas/qtscope/fit_function.py
+++ b/main/ddas/qtscope/fit_function.py
@@ -1,7 +1,8 @@
-import numpy as np
-from scipy.optimize import minimize
 import logging
 import warnings
+
+import numpy as np
+from scipy.optimize import minimize
 
 np.seterr(all='ignore')
 

--- a/main/ddas/qtscope/fit_gauss_creator.py
+++ b/main/ddas/qtscope/fit_gauss_creator.py
@@ -1,5 +1,6 @@
-from fit_function import FitFunction
 import numpy as np
+
+from fit_function import FitFunction
 
 class GaussFit(FitFunction):
     """Gaussian fitting function class used by QtScope.

--- a/main/ddas/qtscope/fit_gauss_p1_creator.py
+++ b/main/ddas/qtscope/fit_gauss_p1_creator.py
@@ -1,5 +1,6 @@
-from fit_function import FitFunction
 import numpy as np
+
+from fit_function import FitFunction
 
 class GaussP1Fit(FitFunction):
     """Gaussian fitting function class used by QtScope.

--- a/main/ddas/qtscope/fit_gauss_p2_creator.py
+++ b/main/ddas/qtscope/fit_gauss_p2_creator.py
@@ -1,5 +1,6 @@
-from fit_function import FitFunction
 import numpy as np
+
+from fit_function import FitFunction
 
 class GaussP2Fit(FitFunction):
     """Gaussian fitting function class used by QtScope.

--- a/main/ddas/qtscope/gui.py
+++ b/main/ddas/qtscope/gui.py
@@ -256,7 +256,7 @@ class MainWindow(QMainWindow):
             msps_list = []
             for i in range(self.sys_utils.get_num_modules()):
                 msps_list.append(self.sys_utils.get_module_msps(i))
-
+                
             # Configure DSP and managers. Performs first time load of DSP
             # settings from the Pixie modules.
             

--- a/main/ddas/qtscope/gui.py
+++ b/main/ddas/qtscope/gui.py
@@ -1,12 +1,13 @@
-import sys
-import os
-import pandas as pd
-import json
-import inspect
 import copy
-from time import sleep
+import inspect
+import json
 import logging
+import os
+import sys
+from time import sleep
+
 import numpy as np
+import pandas as pd
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QCloseEvent
@@ -14,15 +15,15 @@ from PyQt5.QtWidgets import (
     QMainWindow, QVBoxLayout, QWidget, QApplication, QFileDialog
 )
 
-from pixie_utilities import SystemUtilities, RunUtilities, TraceUtilities
-from dsp_manager import DSPManager
-from plot import Plot
-from thread_pool_manager import ThreadPoolManager
 from chan_dsp_gui import ChanDSPGUI 
+import colors
+from dsp_manager import DSPManager
 from mod_dsp_gui import ModDSPGUI
+from pixie_utilities import SystemUtilities, RunUtilities, TraceUtilities
+from plot import Plot
 from run_type import RunType
 from trace_analyzer import TraceAnalyzer
-import colors
+from thread_pool_manager import ThreadPoolManager
 
 # @todo Would like to run the system as per custom DSP parameter formatted
 # text file output -- as currently implemented the save DSP settings do not
@@ -201,9 +202,6 @@ class MainWindow(QMainWindow):
         self.acq_toolbar.b_analyze_trace.clicked.connect(self._analyze_trace)
         self.acq_toolbar.b_read_data.clicked.connect(self._read_data)
         self.acq_toolbar.b_run_control.clicked.connect(self._run_control)
-        self.acq_toolbar.binning.currentTextChanged.connect(
-            lambda bw: self.mplplot.rebin(int(bw))
-        )
         
     ##
     # Public methods
@@ -576,7 +574,6 @@ class MainWindow(QMainWindow):
         self.mplplot.figure.clear()
         module = self.acq_toolbar.current_mod.value()
         channel = self.acq_toolbar.current_chan.value()
-        bin_width = int(self.acq_toolbar.binning.currentText())
 
         # Read from module and get data, then draw:
         
@@ -584,16 +581,12 @@ class MainWindow(QMainWindow):
             for i in range(16):
                 self.run_utils.read_data(module, i, self.active_type)
                 data = self.run_utils.get_data(self.active_type)
-                self.mplplot.draw_run_data(
-                    data, self.active_type, bin_width, 4, 4, i+1
-                )
+                self.mplplot.draw_run_data(data, self.active_type, 4, 4, i+1)
             self.mplplot.update_canvas()
         else:           
             self.run_utils.read_data(module, channel, self.active_type)
             data = self.run_utils.get_data(self.active_type)
-            self.mplplot.draw_run_data(
-                data, self.active_type, bin_width
-            )
+            self.mplplot.draw_run_data(data, self.active_type)
             
     def _read_trace_data(self):
         """Read trace data.

--- a/main/ddas/qtscope/histogram.py
+++ b/main/ddas/qtscope/histogram.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+from PyQt5.QtGui import QIntValidator
+
+from chan_dsp_widget import ChanDSPWidget
+
+class Histogram(ChanDSPWidget):
+    """Histograming DSP tab.
+    
+    Methods
+    -------
+    configure(mgr, mod)
+        Configure the histogramming display. Overridden from the base class.
+    display_dsp(mgr, mod) 
+        Display DSP settings from the dataframe. Overridden from base class.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Histogram class constructor."""
+    
+        # XIA API parameter names:
+        
+        param_names = [
+            "EMIN",
+            "BINFACTOR"
+        ]
+        
+        # Parameter labels on the GUI:
+        
+        param_labels = [
+            "EMin",
+            "BinFactor"
+        ]
+        
+        # Create instance of the parent class with these variables:
+        
+        super().__init__(param_names, param_labels, *args, **kwargs)
+
+    ##
+    # Overridden class methods
+    #
+    
+    def configure(self, mgr, mod):
+        """Overridden template configuration operations.
+
+        Setup integer validators for EMin and BinFactor.
+
+        Parameters
+        ----------
+        mgr : DSPManager
+            Manager for internal DSP and interface for XIA API 
+            read/write operations.
+        mod : int 
+            Module number.
+        """        
+        col1 = self.param_names.index("EMin") + 1
+        col2 = self.param_names.index("BinFactor") + 1        
+        for row in range(1, self.nchannels+1):
+            w1 = self.param_grid.itemAtPosition(row, col1).widget()
+            w1.setValidator(QIntValidator(0, 65535))
+            w2 = self.param_grid.itemAtPosition(row, col2).widget()
+            w2.setValidator(QIntValidator(1, 16))
+        super().configure(mgr, mod)
+
+    def display_dsp(self, mgr, mod):
+        """Overridden display_dsp.
+        
+        Limits precision of EMin and BinFactor to integer.
+
+        Parameters
+        ----------
+        mgr : DSPManager
+            Manager for internal DSP and interface for XIA API 
+            read/write operations.
+        mod : int 
+            Module number.
+        """        
+        for i in range(self.nchannels):
+            for col, name in enumerate(self.param_names, 1):
+                val = np.format_float_positional(
+                    mgr.get_chan_par(mod, i, name),
+                    precision=1,
+                    unique=False, trim="-"
+                )
+                self.param_grid.itemAtPosition(i+1, col).widget().setText(val)
+
+class HistogramBuilder:
+    """Builder method for factory creation."""
+    
+    def __init__(self, *args, **kwargs):
+        """HistogramBuilder class constructor."""
+        
+    def __call__(self, *args, **kwargs):
+        """Create an instance of the widget and return it to the caller.
+
+        Returns
+        -------
+        Histogram 
+            Instance of the DSP class widget.
+        """
+        return Histogram(*args, **kwargs)

--- a/main/ddas/qtscope/histogram.py
+++ b/main/ddas/qtscope/histogram.py
@@ -53,8 +53,8 @@ class Histogram(ChanDSPWidget):
         mod : int 
             Module number.
         """        
-        col1 = self.param_names.index("EMin") + 1
-        col2 = self.param_names.index("BinFactor") + 1        
+        col1 = self.param_names.index("EMIN") + 1
+        col2 = self.param_names.index("BINFACTOR") + 1        
         for row in range(1, self.nchannels+1):
             w1 = self.param_grid.itemAtPosition(row, col1).widget()
             w1.setValidator(QIntValidator(0, 65535))

--- a/main/ddas/qtscope/main.py
+++ b/main/ddas/qtscope/main.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
-import sys
+import logging
 import os
+import sys
 
 sys.path.append(str(os.environ.get("DAQROOT"))+"/ddas/qtscope")
 os.environ['NO_PROXY'] = ""
 os.environ['XDG_RUNTIME_DIR'] = os.environ.get("PWD")
-
-import logging
-
 logging.basicConfig(
     filename="qtscope.log",
     format="%(levelname)s - %(asctime)s: %(message)s"
@@ -15,30 +13,30 @@ logging.basicConfig(
 
 from PyQt5 import QtWidgets, QtCore
 
-from widget_factory import WidgetFactory
 from fit_factory import FitFactory
+from widget_factory import WidgetFactory
 
-from analog_signal import AnalogSignalBuilder
-from trigger_filter import TriggerFilterBuilder
-from energy_filter import EnergyFilterBuilder
-from cfd import CFDBuilder
 from adc_trace import TraceBuilder
-from tau import TauBuilder
-from csra import CSRABuilder
-from mult_coincidence import MultCoincidenceBuilder
-from timing_control import TimingControlBuilder
+from analog_signal import AnalogSignalBuilder
 from baseline import BaselineBuilder
-from qdclen import QDCLenBuilder
+from cfd import CFDBuilder
+from csra import CSRABuilder
+from energy_filter import EnergyFilterBuilder
 from histogram import HistogramBuilder
+from mult_coincidence import MultCoincidenceBuilder
+from qdclen import QDCLenBuilder
+from tau import TauBuilder
+from timing_control import TimingControlBuilder
+from trigger_filter import TriggerFilterBuilder
 
 from crate_id import CrateIDBuilder
 from csrb import CSRBBuilder
 from trigconfig0 import TrigConfig0Builder
 
-from system_toolbar import SystemToolBarBuilder
 from acquisition_toolbar import AcquisitionToolBarBuilder
 from dsp_toolbar import DSPToolBarBuilder
-from plot_toolbar import PlotToolBarBuilder 
+from plot_toolbar import PlotToolBarBuilder
+from system_toolbar import SystemToolBarBuilder
 
 from fit_exp_creator import ExpFitBuilder
 from fit_gauss_creator import GaussFitBuilder

--- a/main/ddas/qtscope/main.py
+++ b/main/ddas/qtscope/main.py
@@ -29,6 +29,7 @@ from mult_coincidence import MultCoincidenceBuilder
 from timing_control import TimingControlBuilder
 from baseline import BaselineBuilder
 from qdclen import QDCLenBuilder
+from histogram import HistogramBuilder
 
 from crate_id import CrateIDBuilder
 from csrb import CSRBBuilder

--- a/main/ddas/qtscope/main.py
+++ b/main/ddas/qtscope/main.py
@@ -124,6 +124,7 @@ def create_chan_dsp_factory():
     factory.register_builder("TimingControl", TimingControlBuilder())
     factory.register_builder("Baseline", BaselineBuilder())
     factory.register_builder("QDCLen", QDCLenBuilder())
+    factory.register_builder("Histogram", HistogramBuilder())
 
     return factory
 

--- a/main/ddas/qtscope/mult_coincidence.py
+++ b/main/ddas/qtscope/mult_coincidence.py
@@ -1,4 +1,3 @@
-import numpy as np
 import inspect
 import logging
 
@@ -8,7 +7,8 @@ if bool(ver[0] >= 1 or (ver[0] == 1 and ver[1] >= 6)):
     from bitarray.util import ba2int, int2ba, zeros
 else:
     from converters import ba2int, int2ba, zeros
-
+import numpy as np
+    
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QRadioButton, QButtonGroup,
@@ -16,8 +16,8 @@ from PyQt5.QtWidgets import (
     QPushButton
 )
 
-import xia_constants as xia
 import colors
+import xia_constants as xia
 
 class MultCoincidence(QWidget):
     """Multiplicity and coincidence tab widget.

--- a/main/ddas/qtscope/pixie_utilities.py
+++ b/main/ddas/qtscope/pixie_utilities.py
@@ -1,11 +1,12 @@
-import sys
 from ctypes import *
 import inspect
 import logging
+import sys
+
 import numpy as np
 
-from run_type import RunType
 from converters import str2char
+from run_type import RunType
 import xia_constants as xia
 
 """pixie_utilities.py

--- a/main/ddas/qtscope/pixie_utilities.py
+++ b/main/ddas/qtscope/pixie_utilities.py
@@ -828,7 +828,8 @@ class TraceUtilities:
         lib.CPixieTraceUtilities_delete.argtypes = [POINTER(c_char)]
 
         self.obj = lib.CPixieTraceUtilities_new()
-    
+        self.logger = logging.getLogger("qtscope_logger")
+
     def read_trace(self, module, channel):
         """Wrapper to read a trace from a single channel.
 

--- a/main/ddas/qtscope/plot.py
+++ b/main/ddas/qtscope/plot.py
@@ -1,30 +1,22 @@
+import copy
+import inspect
+import logging
+from math import ceil, floor
+import sys
+from time import sleep
+
 import matplotlib
 matplotlib.use("Qt5Agg")
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 import numpy as np
-import inspect
-import copy
-import sys
-import logging
-from time import sleep
-from math import ceil, floor
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QMessageBox
 from PyQt5.QtGui import QPaintEvent
 
 from fit_panel import FitPanel
-
-import xia_constants as xia
 from run_type import RunType
-
-##
-# @todo (ASC 8/21/24): Remove the custom binning. There is DSP for energy
-# histogram binning, most people do not use it. Allow users to configure
-# that via a tab or spinbox when starting a run? What effect does it have
-# if set to some strage value for production data (should be none, as it
-# effects onboard histos only)?
-#
+import xia_constants as xia
 
 class Plot(QWidget):
     """Plotting widget for the GUI utilizing the matplotlib Qt5 backend.
@@ -44,12 +36,8 @@ class Plot(QWidget):
     logger : Logger
         QtScope Logger object.
     raw_data : dict
-        Dictionary of default-binned, raw data from the digitizers keyed by 
-        the subplot index on which it is displayed. This data maintains the 
-        same size as the data array returned from the digitizers if the 
-        histograms are rebinned.
-    bin_width : int
-        Bin width in ADC units/bin.
+        Dictionary of raw data from the digitizers keyed by the subplot index 
+        on which it is displayed.
     mgr : DSPManager
         DSP manager for calls to XIA API.
 
@@ -65,8 +53,6 @@ class Plot(QWidget):
         Draw a blank histogram-style canvas when starting a histogram run.
     update_canvas()
         Redraw the entire canvas and all its subplots.
-    rebin()
-        Rebin existing single-channel run histogram data and redraw the plot.
     draw_test_data(idx)
         Draw a test figure with a random number of subplots.
 
@@ -99,7 +85,6 @@ class Plot(QWidget):
         # Data storage and presentation:
         
         self.raw_data = {}
-        self.bin_width = 1 # In samples.
         
         ##
         # Main layout
@@ -171,7 +156,6 @@ class Plot(QWidget):
 
         """
         self.raw_data[idx-1] = data
-        self.bin_width = 1 # Trace data isn't binned.
         ax = self.figure.add_subplot(nrows, ncols, idx)
         ax.plot(self.raw_data[idx-1], drawstyle="steps-post")
         xdt = self.mgr.get_chan_par(mod, chan, "XDT")*1000 # in ns.
@@ -228,7 +212,7 @@ class Plot(QWidget):
         self.canvas.draw_idle()
         
     def draw_run_data(
-            self, data, run_type, bin_width, nrows=1, ncols=1, idx=1
+            self, data, run_type, nrows=1, ncols=1, idx=1
     ):
         """Draws a data histogram on the plot canvas.
 
@@ -238,8 +222,6 @@ class Plot(QWidget):
             Single-channel run data.
         run_type : Enum member 
             Type of run data to draw.
-        bin_width : int
-            Width of each bin in ADC units.
         nrows : int, optional, default=1
             Number of subplot rows.
         ncols : int, optional, default=1
@@ -249,10 +231,8 @@ class Plot(QWidget):
 
         """
         self.raw_data[idx-1] = data
-        self.bin_width = bin_width
         ax = self.figure.add_subplot(nrows, ncols, idx)
-        nbins = int(xia.MAX_HISTOGRAM_LENGTH/self.bin_width)        
-        self._plot_histogram(ax, idx-1, nbins)
+        self._plot_histogram(ax, idx-1)
                 
         if run_type == RunType.HISTOGRAM:
             ax.set_xlabel("Energy (ADC units)")
@@ -307,33 +287,6 @@ class Plot(QWidget):
         """
         sleep(0.5)
         self.canvas.draw()
-
-    def rebin(self, bin_width):
-        """Rebin histogrammed data.
-
-        Interactive rebinning is only supported for single channel plots, as 
-        the plotter keeps no history of all the data it is displaying.
-
-        Parameters
-        ----------
-        bin_width : int
-            Histogramm bin width in ADC values/bin.
-
-        """
-        self.bin_width = bin_width
-        axs = self.figure.get_axes()
-        for idx, ax in zip(range(len(axs)), axs):
-            npts = len(self.raw_data[idx]) if self.raw_data else 0
-            if npts == xia.MAX_HISTOGRAM_LENGTH:
-                nbins = int(xia.MAX_HISTOGRAM_LENGTH/self.bin_width)
-                # Remove all drawn histograms but not any axis labeling, etc.
-                # and reset the fit panel before plotting the rebinned data:
-                for line in ax.get_lines():
-                    line.remove()
-                self.fit_panel.reset()
-                self._plot_histogram(ax, idx, nbins)
-            self._set_yscale(ax)
-            self.canvas.draw_idle()
 
     def get_subplot_data(self, chan):
         """Get data from a subplot (channel).
@@ -439,12 +392,11 @@ class Plot(QWidget):
             else:
                 ax.set_ylim(0, 1)
 
-    def _plot_histogram(self, ax, idx, nbins):
+    def _plot_histogram(self, ax, idx):
         """Create and plot histogrammed data.
 
-        Raw histograms with default binning read are used as data weights 
-        to construct a NumPy histogram which is plotted on the provided axes 
-        using Axes.plot.
+        Histograms are counts and therefore governed by Poisson statistics. 
+        As such, each bin in the histogram has weight = data.
 
         Parameters
         ----------
@@ -452,8 +404,6 @@ class Plot(QWidget):
             matplotlib class containing the figure elements.
         idx : int
             Raw data index containing the weights.
-        nbins : int
-            Number of histogram bins.
 
         Raises
         ------
@@ -462,8 +412,10 @@ class Plot(QWidget):
 
         """
         data, bins = np.histogram(
-            [i for i in range(xia.MAX_HISTOGRAM_LENGTH)], bins=nbins,
-            range=(0, xia.MAX_HISTOGRAM_LENGTH), weights=self.raw_data[idx]
+            [i for i in range(xia.MAX_HISTOGRAM_LENGTH)],
+            bins=xia.MAX_HISTOGRAM_LENGTH,
+            range=(0, xia.MAX_HISTOGRAM_LENGTH),
+            weights=self.raw_data[idx]
         )
         # Drop the rightmost bin edge for the x-axis data. y-value is the left
         # edge of the bin, as in, e.g. ROOT.
@@ -524,22 +476,13 @@ class Plot(QWidget):
                 float(self.fit_panel.p5.text())
             ]
 
-            # Get the indices of the x-data array corresponding to the limits.
-            # Greatly simplified by the following:
-            #     - Data comes with default binning 1 unit/bin,
-            #     - Data length always a power of 2,
-            #     - Traces cannot be rebinned,
-            #     - Histogram binning always a factor of 2.
-            # So we can simply use the bin width to reconstruct the index of
-            # potentially rebinned data by rounding, otherwise we just get the
-            # indices back.
-            idx_min = ceil(int(limits[0]/self.bin_width))
-            idx_max = floor(int(limits[1]/self.bin_width))
+            # Get the indices of the x-data array corresponding to the limits:
+            idx_min = int(limits[0])
+            idx_max = int(limits[1])
                 
             self.logger.debug(f"Fit limits: {limits[0]}, {limits[1]}")
             self.logger.debug(f"Fit limit indices: {idx_min}, {idx_max}")
             self.logger.debug(f"Fit panel guess params: {params}")
-            self.logger.debug(f"Data binning factor: {self.bin_width}")
 
             # If the current subplot has data, get the fit limits and call the
             # fit function's start() rountine to perform the fit.
@@ -547,7 +490,8 @@ class Plot(QWidget):
                 x = ax.lines[0].get_xdata()[idx_min:idx_max]
                 y = ax.lines[0].get_ydata()[idx_min:idx_max]
 
-                result = fit.start(x+self.bin_width/2, y, params, ax)
+                # x value is center of bin:
+                result = fit.start(x+0.5, y, params, ax)
 
                 # Update the canvas with the results:
                 x_fit = np.linspace(limits[0], limits[1], 10000)

--- a/main/ddas/qtscope/thread_pool_manager.py
+++ b/main/ddas/qtscope/thread_pool_manager.py
@@ -1,6 +1,6 @@
+import logging
 import sys
 import traceback
-import logging
 
 from PyQt5.QtCore import QObject, QThreadPool, QRunnable, pyqtSignal, pyqtSlot
 

--- a/main/ddas/qtscope/timing_control.py
+++ b/main/ddas/qtscope/timing_control.py
@@ -1,7 +1,6 @@
 from PyQt5.QtWidgets import QPushButton
 
 from chan_dsp_widget import ChanDSPWidget
-
 import colors
 
 class TimingControl(ChanDSPWidget):

--- a/main/ddas/qtscope/trace_analyzer.py
+++ b/main/ddas/qtscope/trace_analyzer.py
@@ -1,8 +1,9 @@
+from dataclasses import dataclass    
 import inspect
 import logging
 import math
+
 import numpy as np
-from dataclasses import dataclass    
 
 # @todo This class needs to know the module MSPS so it can set the fixed values
 # for the CFD parameters. Probably the easiest way is to have some module

--- a/main/ddas/qtscope/xia_constants.py
+++ b/main/ddas/qtscope/xia_constants.py
@@ -80,7 +80,9 @@ CHAN_PARS = [
     "MultiplicityMaskH",
     "ExternDelayLen",
     "FtrigoutDelay",
-    "ChanTrigStretch"
+    "ChanTrigStretch",
+    "BINFACTOR",
+    "EMIN"
 ]
 
 # XIA module parameter names:

--- a/main/ddas/readout/DDASFirmwareVersions.txt.in
+++ b/main/ddas/readout/DDASFirmwareVersions.txt.in
@@ -69,6 +69,13 @@
 @dspdir@/Pixie16_current_16b250m.var
 8
 
+[Rev0xH-14Bit-250MSPS]
+@firmwaredir@/syspixie16_current_14b250m.bin
+@firmwaredir@/fippixie16_current_14b250m.bin
+@dspdir@/Pixie16_current_14b250m.ldr
+@dspdir@/Pixie16_current_14b250m.var
+8
+
 [Rev0xF-12Bit-500MSPS]
 @firmwaredir@/syspixie16_current_12b500m.bin
 @firmwaredir@/fippixie16_current_12b500m.bin

--- a/main/ddas/readout/DDASFirmwareVersions.txt.in
+++ b/main/ddas/readout/DDASFirmwareVersions.txt.in
@@ -69,13 +69,6 @@
 @dspdir@/Pixie16_current_16b250m.var
 8
 
-[Rev0xH-14Bit-250MSPS]
-@firmwaredir@/syspixie16_current_14b250m.bin
-@firmwaredir@/fippixie16_current_14b250m.bin
-@dspdir@/Pixie16_current_14b250m.ldr
-@dspdir@/Pixie16_current_14b250m.var
-8
-
 [Rev0xF-12Bit-500MSPS]
 @firmwaredir@/syspixie16_current_12b500m.bin
 @firmwaredir@/fippixie16_current_12b500m.bin

--- a/main/ddas/readout/Makefile.am
+++ b/main/ddas/readout/Makefile.am
@@ -97,6 +97,7 @@ install-exec-hook:
 	$(mkinstalldirs) $(SHAREDIR)
 	$(mkinstalldirs) $(SHAREDIR)/crate_1
 	$(INSTALL_DATA) DDASFirmwareVersions.txt $(SHAREDIR)
+	$(INSTALL_DATA) pixieserver.tcl $(SHAREDIR)
 	$(INSTALL_DATA) @srcdir@/crate_1/* $(SHAREDIR)/crate_1
 	$(mkinstalldirs) $(bindir)
 	@INSTALL_SCRIPT@ @srcdir@/ddasReadout.tcl @bindir@/ddasReadout
@@ -104,4 +105,4 @@ install-exec-hook:
 clean-local:
 	rm -f @srcdir@/ddasSortOptions.{h,c}
 
-EXTRA_DIST=DDASFirmwareVersions.txt.in crate_1 ddasSortOptions.ggo ddasReadout.tcl readout.xml sorter.xml readoutdriver.xml readout.dox
+EXTRA_DIST=DDASFirmwareVersions.txt.in crate_1 ddasSortOptions.ggo ddasReadout.tcl readout.xml sorter.xml readoutdriver.xml readout.dox pixieserver.tcl.in

--- a/main/ddas/readout/ddasReadout.tcl
+++ b/main/ddas/readout/ddasReadout.tcl
@@ -180,7 +180,7 @@ if {$fastboot} {
     set fbstring ""
 }
 
-set readoutCmd "$fbstring $infstring SCALER_SECONDS=$scalerSecs FIFO_THRESHOLD=$fifoThreshold EVENT_BUFFER_SIZE=$bufferSize $readoutCmd"
+set readoutCmd "$infstring $fbstring SCALER_SECONDS=$scalerSecs FIFO_THRESHOLD=$fifoThreshold EVENT_BUFFER_SIZE=$bufferSize $readoutCmd"
 
 foreach optMapEntry $ddasOptionMap {
     set opt [lindex $optMapEntry 0]

--- a/main/ddas/readout/pixieserver.tcl.in
+++ b/main/ddas/readout/pixieserver.tcl.in
@@ -1,0 +1,4 @@
+#---- pixieserver.tcl:
+
+lappend auto_path [file join @prefix@ TclLibs]
+package require pixieplugin

--- a/release_notes
+++ b/release_notes
@@ -2,6 +2,8 @@
 * Pixieserver and pixieplugin updates for 12.x (Issue #255)
 * install example pixieserver.tcl script in share/ddasreadout
 * Fix `make dist` issues for ddasdumper (Issue #257)
+* QtScope uses XIA parameter for binning histogram data
+* Offline mode for XIA API 4
 == 12.1-007 ==
 
 == 12.1-006 ==

--- a/release_notes
+++ b/release_notes
@@ -1,4 +1,7 @@
 == 12.1-007 ==
+* Pixieserver and pixieplugin updates for 12.x (Issue #255)
+* install example pixieserver.tcl script in share/ddasreadout
+* Fix `make dist` issues for ddasdumper (Issue #257)
 == 12.1-007 ==
 
 == 12.1-006 ==


### PR DESCRIPTION
Lots of QtScope fixes/improvements:
* remove my custom binning
* set histo binning by channel parameter
* simplify data generation

DDAS:
* offline mode for api 4
* add hardware type to support 32-channel xia boards
* use xia module_config struct and PixieGetModuleInfo to query module info
* Fixes for #255 #257 

Note that support for 32 channel boards is still a work in progress. A HW type was added for these modules to support the crate simulation framework provided by XIA which contains a rev H 32 channel board. This basically allows us to use the existing methods of determining the system config in offline mode even though the module is not fully supported.