### PR TITLE
Add ability to set time offset divisor.

### DIFF
--- a/main/daq/format/CRingPhysicsEventCountItem.cpp
+++ b/main/daq/format/CRingPhysicsEventCountItem.cpp
@@ -215,6 +215,17 @@ CRingPhysicsEventCountItem::getTimeDivisor() const
     reinterpret_cast<pPhysicsEventCountItemBody>(getBodyPointer());
   return pItem->s_offsetDivisor;
 }
+/**
+ * setTimeDivisor
+ *    Set the time offset divisor value.
+ * @param divisor - divisor to set.
+ */
+void
+CRingPhysicsEventCountItem::setTimeDivisor(int divisor) {
+   pPhysicsEventCountItemBody pItem =
+    reinterpret_cast<pPhysicsEventCountItemBody>(getBodyPointer());
+   pItem->s_offsetDivisor = divisor;
+}
 /*!
    set the time offset.
    \param offset - new value of time offset.

--- a/main/daq/format/CRingPhysicsEventCountItem.h
+++ b/main/daq/format/CRingPhysicsEventCountItem.h
@@ -67,6 +67,7 @@ public:
   void     setTimeOffset(uint32_t offset);
   float    computeElapsedTime() const;
   uint32_t getTimeDivisor() const;
+  void     setTimeDivisor(int divisor);
 
   time_t   getTimestamp() const;
   void     setTimestamp(time_t stamp);


### PR DESCRIPTION
This is added to support the case when there's a time divisor for event count items but no
event building data (timestamp, sid, barrier).   This is the case
for e.g. fribdaq-readout in mesytec-mvlc.

Originally, there was no way to set the time divisor in that case.