### PR TITLE
Rfoxkendo/issue304

### DIFF
--- a/main/usb/vmusb/daqconfig/C785.cpp
+++ b/main/usb/vmusb/daqconfig/C785.cpp
@@ -296,7 +296,7 @@ C785::addToChain(CVMUSB& controller,
    Parameter                 Default
    -thresholds               list of 32 0's.
    -smallthresholds          false
-   -ipl                      6 (interrupt 6 is expected by the rdo thread.
+   -ipl                      0 disabled
    -vector                   0x80
    -highwater                MEBDepth*3/4  (3/4 full event buffer).
    -fastclear                0
@@ -333,7 +333,7 @@ C785::onAttach(CReadoutModule& configuration)
   m_pConfiguration->addParameter("-smallthresholds", XXUSB::CConfigurableObject::isBool,
 				 NULL, "false");
   m_pConfiguration->addParameter("-ipl", XXUSB::CConfigurableObject::isInteger,
-				 &iplRange, "6");
+				 &iplRange, "0");
   m_pConfiguration->addParameter("-vector", XXUSB::CConfigurableObject::isInteger,
 				 &vectorRange, "0x80");
 

--- a/main/usb/vmusb/vmusbReadout_man.xml
+++ b/main/usb/vmusb/vmusbReadout_man.xml
@@ -180,9 +180,8 @@ caenv956 cget <replaceable>name</replaceable>
                   The interrupt priority level the module should use to request
                   a VME bus interrupt.  This defaults to 6 and should be set to
                   zero to disable interrupts.  Normally interrupts will be used
-                  to trigger an interrupt triggered stack.  The default of 6
-                  is historical in nature, in most cases for,
-                  the default should be overridden to zero.
+                  to trigger an interrupt triggered stack.  The default value
+                  is 0 which disables module interrupts.
                </para>
             </listitem>
          </varlistentry>
@@ -8946,8 +8945,8 @@ mdpp16qdc cget <replaceable>name</replaceable>
                                          Standard streaming mode
                                      </para>
                                  </listitem>
-                             <varlistentry>
                              </varlistentry>
+                             <varlistentry>
                                  <term><literal>16</literal></term>
                                  <listitem>
                                      <para>
@@ -9969,8 +9968,8 @@ mdpp32scp cget <replaceable>name</replaceable>
                                          Standard streaming mode
                                      </para>
                                  </listitem>
-                             <varlistentry>
                              </varlistentry>
+                             <varlistentry>
                                  <term><literal>16</literal></term>
                                  <listitem>
                                      <para>


### PR DESCRIPTION
Resolve issue #304 - CAEN 32 channel modules for VMUSBReadout default -ipl to 6 shoulid default to 0.
* Fixes that in the code.
* Fixes the documentation for the ```adc``` command to reflect that.