### PR TITLE
Rfoxkendo/issue294

### DIFF
--- a/main/usb/vmusb/core/COutputThread.cpp
+++ b/main/usb/vmusb/core/COutputThread.cpp
@@ -788,9 +788,7 @@ COutputThread::event(void* pData)
       m_pBuffer            = pNewBuffer;
       m_pCursor            = m_pBuffer + m_nWordsInBuffer * sizeof(uint16_t);
       m_nOutputBufferSize += newSize;
-      // TODO:
-      // Augh this will have changed the last header location too!
-      // maybe make it an offset not a pointer that's invariant!!!!
+      
     } else {
       throw std::string("Failed to resize event buffer to fit an oversized segment");
     }

--- a/main/usb/vmusb/core/COutputThread.cpp
+++ b/main/usb/vmusb/core/COutputThread.cpp
@@ -106,7 +106,7 @@ COutputThread::COutputThread(std::string ring, CSystemControl& sysControl) :
   m_pBeginRunCallback(0),
   m_systemControl(sysControl)
 #ifdef VMUSB_END_OF_EVENT_WORKAROUND
-  ,m_pLastHeader(0)
+  ,m_LastHeader(-1)		// Not set.
 #endif
 {
     memset(&m_statistics, 0, sizeof(m_statistics));
@@ -788,7 +788,9 @@ COutputThread::event(void* pData)
       m_pBuffer            = pNewBuffer;
       m_pCursor            = m_pBuffer + m_nWordsInBuffer * sizeof(uint16_t);
       m_nOutputBufferSize += newSize;
-
+      // TODO:
+      // Augh this will have changed the last header location too!
+      // maybe make it an offset not a pointer that's invariant!!!!
     } else {
       throw std::string("Failed to resize event buffer to fit an oversized segment");
     }
@@ -798,6 +800,9 @@ COutputThread::event(void* pData)
   // Next we can copy our data to the output buffer and update the cursor
   // remembering that the size is not self inclusive:
   //
+ #ifdef VMUSB_END_OF_EVENT_WORKAROUND
+  uint16_t* dest = reinterpret_cast<uint16_t*>(m_pCursor);
+#endif
   memcpy(m_pCursor, pData, segmentSize*sizeof(uint16_t));
   m_nWordsInBuffer += segmentSize;
   m_pCursor += segmentSize*sizeof(uint16_t); // advance the cursor
@@ -823,22 +828,25 @@ COutputThread::event(void* pData)
 
     // Ajust the header properly
 
-    if (segmentSize) {
-      header = header & (~VMUSBEventLengthMask) | segmentSize;  //Sset the adjust segment size...
-      *pSegment = header;                                       // Replace the original header
-    } else {
+
+    // Note the header length is not self inclusive hence the -1
+    header = header & (~VMUSBEventLengthMask) | (segmentSize-1);  //Sset the adjust segment size...
+    *dest = header;        // Relace it in our copy-in buffer.
+    if (header == 0) {
       // That left an empty segment so retract the header too...
       // if there was no last header that means we're going to emit an empty event...
       // but that means the user has an event stack with no modules so they
       // get what they deserve.
 
-      if (m_pLastHeader) {
+      if (m_LastHeader >= 0) {
         m_pCursor -= sizeof(uint16_t);    // Retract the empty header
         m_nWordsInBuffer--;
         
-        auto lastHeader = *m_pLastHeader;  // Remove the continuation bit
+        uint16_t* pLastHeader =
+	    reinterpret_cast<uint16_t*>(m_pBuffer + m_LastHeader);  // Remove the continuation bit
+	uint16_t lastHeader = *pLastHeader;
         lastHeader &= ~VMUSBContinuation;  // from the previous header.
-        *m_pLastHeader = lastHeader;
+        *pLastHeader = lastHeader;
       } 
     }
 
@@ -895,14 +903,16 @@ COutputThread::event(void* pData)
         
     m_nEventsSeen++;
 #ifdef VMUSB_END_OF_EVENT_WORKAROUND
-    m_pLastHeader = nullptr;      // Next event does not have a prior header.
+    m_LastHeader = -1;      // Next event does not have a prior header.
 #endif
   }
 #ifdef VMUSB_END_OF_EVENT_WORKAROUND
   else {
-    // Save the header so we can adjust if the last segment only has a marker:
-
-    m_pLastHeader = pSegment;
+    // Save the header offset so we can adjust if the last segment only has a marker:
+    // Note we save the offset because the buffer might get reallocated/moved on the
+    // next segment, invalidating a pointer.
+      
+      m_LastHeader = reinterpret_cast<uint8_t*>(dest) - m_pBuffer;
   }
 #endif
 

--- a/main/usb/vmusb/core/COutputThread.cpp
+++ b/main/usb/vmusb/core/COutputThread.cpp
@@ -105,6 +105,9 @@ COutputThread::COutputThread(std::string ring, CSystemControl& sysControl) :
   m_pSclrTimestampExtractor(0),
   m_pBeginRunCallback(0),
   m_systemControl(sysControl)
+#ifdef VMUSB_END_OF_EVENT_WORKAROUND
+  ,m_pLastHeader(0)
+#endif
 {
     memset(&m_statistics, 0, sizeof(m_statistics));
 }
@@ -804,6 +807,42 @@ COutputThread::event(void* pData)
   // If that was the last segment submit it and reset cursors and counters.
 
   if (!haveMore) {			    // Ending segment:
+  #ifdef VMUSB_END_OF_EVENT_WORKAROUND
+    // If this is enabled, we have a trailing marker we have to delete, and
+    // we need to adjust the wordcount in the segment header down by that
+    // marker...and deal with the edge case that this is the only 
+    // word in that segment.... in that case we need to retract the
+    // header as well and remove the contiuation bit from the last
+    // header:
+
+    // remove the marker:
+
+    segmentSize--;
+    m_pCursor -= sizeof(uint16_t);
+    m_nWordsInBuffer--;
+
+    // Ajust the header properly
+
+    if (segmentSize) {
+      header = header & (~VMUSBEventLengthMask) | segmentSize;  //Sset the adjust segment size...
+      *pSegment = header;                                       // Replace the original header
+    } else {
+      // That left an empty segment so retract the header too...
+      // if there was no last header that means we're going to emit an empty event...
+      // but that means the user has an event stack with no modules so they
+      // get what they deserve.
+
+      if (m_pLastHeader) {
+        m_pCursor -= sizeof(uint16_t);    // Retract the empty header
+        m_nWordsInBuffer--;
+        
+        auto lastHeader = *m_pLastHeader;  // Remove the continuation bit
+        lastHeader &= ~VMUSBContinuation;  // from the previous header.
+        *m_pLastHeader = lastHeader;
+      } 
+    }
+
+  #endif
     //
     // IF we were given a timestamp extractor we create an event with full
     // body header.
@@ -834,11 +873,9 @@ COutputThread::event(void* pData)
     // we transparently added to the readout stack to force
     // end of event to fire.
 
-#ifndef VMUSB_END_OF_EVENT_WORKAROUND
+
     event.setBodyCursor(pEnd);
-#else
-    event.setBodyCursor(pEnd - sizeof(uint16_t));
-#endif
+
     event.updateSize();
     event.commitToRing(*m_pRing);
     delete pEvent;
@@ -857,7 +894,17 @@ COutputThread::event(void* pData)
     
         
     m_nEventsSeen++;
+#ifdef VMUSB_END_OF_EVENT_WORKAROUND
+    m_pLastHeader = nullptr;      // Next event does not have a prior header.
+#endif
   }
+#ifdef VMUSB_END_OF_EVENT_WORKAROUND
+  else {
+    // Save the header so we can adjust if the last segment only has a marker:
+
+    m_pLastHeader = pSegment;
+  }
+#endif
 
 }
 

--- a/main/usb/vmusb/core/COutputThread.h
+++ b/main/usb/vmusb/core/COutputThread.h
@@ -146,8 +146,8 @@ private:
 
 #ifdef VMUSB_END_OF_EVENT_WORKAROUND
   // We need to keep track of the last header pointer.
-
-  uint16_t*    m_pLastHeader;
+  // Since the buffer can be re-allocated we use a buffer offset
+    ssize_t    m_LastHeader;        // Signed because 0 is a valid last header.
 #endif
 
   // Constuctors and other canonicals.

--- a/main/usb/vmusb/core/COutputThread.h
+++ b/main/usb/vmusb/core/COutputThread.h
@@ -144,6 +144,11 @@ private:
   StateChangeCallback m_pBeginRunCallback;
   CSystemControl& m_systemControl;
 
+#ifdef VMUSB_END_OF_EVENT_WORKAROUND
+  // We need to keep track of the last header pointer.
+
+  uint16_t*    m_pLastHeader;
+#endif
 
   // Constuctors and other canonicals.
 


### PR DESCRIPTION
Issue #294 - The initial resolution of this issue did not allow for the fact that the marker is also counted in the hardware header produced by the VMUSB.  This pull contains a resolution for that problem.  Tested cases:
*  The resulting data are entirely empty - a single header with 0 length field remains.
*  The data are a single segment - the header for that segment is adjusted to be correct.
*  The data are multiple segments but the removal of the marker leaves a non zero final segment - the header of that segment is adjusted to be correct.
*  The data are multiple segments but the marker is the only item in the final segment.  The final header is removed and the continuation bit is turned off in the new final segment.