### PR TITLE
Integrate rust tools

### DIFF
--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -33,12 +33,18 @@ endif
 
 SRSDIR=srs
 
+# Rust tools:
+
+if BUILD_RUST_TOOLS
+	RUSTSUBDIRS=rust_tools
+endif
+
 
 SUBDIRS = base caenfw-common servers base/dataflow \
 	daq utilities $(DOCDIR) \
 	sbs usb/common/configurableobject $(EPICSDIRS) $(USBDIR) $(DDASDIR) $(CAENSUPPORTDIRS) \
 	$(CAENNGDIR) $(SRSDIR) $(MVLCGENDIR) \
-	examples
+	examples $(RUSTSUBDIRS)
 
 DIST_SUBDIRS = base caenfw-common servers base/dataflow daq utilities \
 	docbuild docconfig simplesetups sbs epics usb ddas \

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -747,6 +747,60 @@ AC_SUBST(THREADLD_FLAGS)
 
 AC_CONFIG_LINKS([utilities/filter/run-0000-00.evt:utilities/filter/run-0000-00.evt])
 
+#  Start support for integrating rust tools:
+
+AC_ARG_ENABLE([rust-tools],
+	AS_HELP_STRING([--enable-rust-tools], [Build RUST tools and toys]),
+	[enable_rust=$enableval], [enable_rust=no]
+)
+if test "x$enable_rust" = "xyes"
+then
+	# Figure out where the rust toolchains are. For FRIB containers,
+	# it's in /usr/cargo/bin  for user installs it may be in 
+	# ~/.cargo/bin
+	#  Those are the things we support -- if neither exists,
+	#  the usr needs to install RUST; we won't do it for them.
+	AM_CONDITIONAL([BUILD_RUST_TOOLS], [true])
+	AC_MSG_CHECKING([Checking for Rust toolchain])
+	if test -x /usr/cargo/bin/cargo
+	then
+		RUST_TOOL_DIR=/usr/cargo/bin
+		BUILD_RUST_TOOLS=1
+	else 
+		if test -x ~/.cargo/bin/cargo
+		then
+			BUILD_RUST_TOOLS=1
+			RUST_TOOL_DIR=~/.cargo/bin
+		else
+			AC_MSG_ERROR([You need to install the rust toolchain to --enable-rust-tools see https://man7.org/linux/man-pages/man1/test.1.html])
+		fi
+	fi
+	RUST_CARGO="${RUST_TOOL_DIR}/cargo"
+	
+	AC_SUBST(RUST_TOOL_DIR)
+	AC_SUBST(RUST_CARGO)
+
+	#Incorporate the rust directory tree into builddir:
+	# The next symbol is a list of the 
+	# Git repositories to clone into rust_tools:
+	rust_repos="https://github.com/FRIBDAQ/rust-portman"
+	rust_repos="${rust_repos} https://github.com/FRIBDAQ/rust-ringtostdout"
+	rust_repos="${rust_repos} https://github.com/FRIBDAQ/rust-ringmaster"
+	RUST_SUBDIRS=""
+	for repo in ${rust_repos}
+	do 
+		AC_MSG_NOTICE([Cloning rust tool from ${repo}])
+		(cd rust_tools; git clone  ${repo})
+		subdir=`basename ${repo}`
+		RUST_SUBDIRS="${RUST_SUBDIRS} ${subdir}"
+	done
+	AC_SUBST(RUST_SUBDIRS)
+
+else 
+	AM_CONDITIONAL([BUILD_RUST_TOOLS], [false])	
+fi
+
+
 #---------------------------------------------------------------------------
 # Generate the following from their .in's (note that Automake takes
 # *.am -> *.in.
@@ -978,6 +1032,7 @@ Makefile
     srs/sorter/Makefile
 	mvlc/Makefile
     cookbooks/Makefile
+	rust_tools/Makefile
 ])
 
 AC_OUTPUT

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -788,7 +788,7 @@ then
 	rust_repos="${rust_repos} https://github.com/FRIBDAQ/rust-ringmaster"
 	RUST_SUBDIRS=""
 
-	mkdir -p rust-tools
+	mkdir -p rust_tools
 	for repo in ${rust_repos}
 	do 
 		AC_MSG_NOTICE([Cloning rust tool from ${repo}])

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -787,11 +787,14 @@ then
 	rust_repos="${rust_repos} https://github.com/FRIBDAQ/rust-ringtostdout"
 	rust_repos="${rust_repos} https://github.com/FRIBDAQ/rust-ringmaster"
 	RUST_SUBDIRS=""
+
+	mkdir -p rust-tools
 	for repo in ${rust_repos}
 	do 
 		AC_MSG_NOTICE([Cloning rust tool from ${repo}])
-		(cd rust_tools; git clone  ${repo})
 		subdir=`basename ${repo}`
+		rm -rf rust_tools/${subdir}
+		(cd rust_tools; git clone  ${repo})
 		RUST_SUBDIRS="${RUST_SUBDIRS} ${subdir}"
 	done
 	AC_SUBST(RUST_SUBDIRS)

--- a/main/rust_tools/Makefile.am
+++ b/main/rust_tools/Makefile.am
@@ -27,12 +27,28 @@
 # subdirs containing rust packages in this tree of the repo.
 
 RUST_BUILTIN=
+INSTALL_DIR=@bindir@/rust     # Segragate the rust bins..
 
 all-local:
 	for tool in @RUST_SUBDIRS@ ; do (cd $${tool}; @RUST_CARGO@ build --release); done
-	for tool in ${RUST_BUILTIN}; do \
-		(cd $$tool; @RUST_CARGO@ build --release --target-dir @builddir@/$$tool/target); \
+	for tool in $(RUST_BUILTIN); do \
+		(cd @srcdir@/$$tool; @RUST_CARGO@ build --release --target-dir @builddir@/$$tool/target); \
 	done
 
 
+#
+# Installing the packages is a matter of parsing the cargos to get the
+# list of files to install and then installing them.  See comments above about
+# how to parse Cargo.toml.
+#
+
 install-exec-local:
+	$(mkinstalldirs) $(INSTALL_DIR)
+	files=""; \
+	for tool in @RUST_SUBDIRS@; do \
+		executable=`cat $$tool/Cargo.toml | grep "name =" | cut -d= -f2|tr -d " \""`; \
+		executable="@builddir@/$$tool/target/release/$${executable}"; \
+		files="$${files} $${executable}";   \
+	done; \
+	$(INSTALL_PROGRAM) $${files} $(INSTALL_DIR)
+

--- a/main/rust_tools/Makefile.am
+++ b/main/rust_tools/Makefile.am
@@ -61,4 +61,7 @@ install-exec-local:
 		$(INSTALL_PROGRAM) $${files} $(INSTALL_DIR); \
 	fi
 
+# Finally, since the Rust built ins are not known to the
+# autotools directly, we need to include them in the tarball too:
 
+EXTRA_DIST=$(RUST_BUILTIN)

--- a/main/rust_tools/Makefile.am
+++ b/main/rust_tools/Makefile.am
@@ -46,9 +46,19 @@ install-exec-local:
 	$(mkinstalldirs) $(INSTALL_DIR)
 	files=""; \
 	for tool in @RUST_SUBDIRS@; do \
-		executable=`cat $$tool/Cargo.toml | grep "name =" | cut -d= -f2|tr -d " \""`; \
+		executable=`cat @builddir@/$$tool/Cargo.toml | grep "name =" | cut -d= -f2|tr -d " \""`; \
 		executable="@builddir@/$$tool/target/release/$${executable}"; \
 		files="$${files} $${executable}";   \
 	done; \
 	$(INSTALL_PROGRAM) $${files} $(INSTALL_DIR)
+	file=""; \
+	for tool in $(RUST_BUILTIN) ; do \
+		executable=`cat @srcdir@/$$tool/Cargo.toml | grep "name =" | cut -d= -f2|tr -d " \""`; \
+		executable="@builddir@/$$tool/target/release/$${executable}"; \
+		files="$${files} $${executable}";   \
+	done; \
+	if test "x$${files}" != "x"; then \
+		$(INSTALL_PROGRAM) $${files} $(INSTALL_DIR); \
+	fi
+
 

--- a/main/rust_tools/Makefile.am
+++ b/main/rust_tools/Makefile.am
@@ -1,0 +1,7 @@
+#
+# Build the rust stuff in --release mode
+#
+all-local:
+	for tool in @RUST_SUBDIRS@ ; do (cd $${tool}; @RUST_CARGO@ build --release); done
+
+install-exec-local:

--- a/main/rust_tools/Makefile.am
+++ b/main/rust_tools/Makefile.am
@@ -26,13 +26,13 @@
 #  Maintain the variable below with the space separated names of the
 # subdirs containing rust packages in this tree of the repo.
 
-RUST_BUILTIN=
+RUST_BUILTIN=ring_monitor
 INSTALL_DIR=@bindir@/rust     # Segragate the rust bins..
 
 all-local:
 	for tool in @RUST_SUBDIRS@ ; do (cd $${tool}; @RUST_CARGO@ build --release); done
 	for tool in $(RUST_BUILTIN); do \
-		(cd @srcdir@/$$tool; @RUST_CARGO@ build --release --target-dir @builddir@/$$tool/target); \
+		(cd @srcdir@/$$tool; @RUST_CARGO@ build --release --target-dir @abs_builddir@/$$tool/target); \
 	done
 
 

--- a/main/rust_tools/Makefile.am
+++ b/main/rust_tools/Makefile.am
@@ -1,7 +1,38 @@
 #
 # Build the rust stuff in --release mode
 #
+#  Note, only executables are supported.  libs should be published and
+#  pulled in via dependencies in the executable's Cargo.toml
+#
+#  Note the are two types of Rust packagres.
+#  Those which configure brought in from othe4r repositories
+#  and those which are in the src dir.
+#  The @RUST_SUBDIRS@ config variable has the list of
+#  subdirectories in @builddir@ which were brought in by config.
+#  Those can be directly built as they are in the @builddir@ to begin with.
+#  The second set of rust items have been added to the NSCLDAQ git repo.
+#  Those are listed in RUST_BUILTIN and must be maintained in this file
+#  as new rust code is added to the repository.  Those are relative to
+#  @srcdir@ and must be built with --target-dir on cargo to support out of
+#  tree builds.  In the end all will wind up in some
+#  @builddir@/package/target/release
+#
+#  Cargo.toml in the source directory can be parsed to get the name of the
+#  file to install:
+#  Specifically:
+#    cat Cargo.toml | grep "name =" | cut -d= -f2|tr -d " \""
+#  Produces the name of the executable produced.
+
+#  Maintain the variable below with the space separated names of the
+# subdirs containing rust packages in this tree of the repo.
+
+RUST_BUILTIN=
+
 all-local:
 	for tool in @RUST_SUBDIRS@ ; do (cd $${tool}; @RUST_CARGO@ build --release); done
+	for tool in ${RUST_BUILTIN}; do \
+		(cd $$tool; @RUST_CARGO@ build --release --target-dir @builddir@/$$tool/target); \
+	done
+
 
 install-exec-local:


### PR DESCRIPTION
Provide support for --enable-rust-tools to build and integrate:
*  External rust tools from other repositories listed in configure.ac's rust_repos respository list.
*  Rust tools in main/rust_tools that are listed in the Makefile.am in that directory's RUST_BUILTIN variable.

At present there's a placeholder tool ring_monitor for which I'll make an issue to actually write.  Rust tools are installed in @bindir@/rust at present.