### PR TITLE
*  fix AM_CONDITIONALs for EPICS to be as per autotools docs.

### DIFF
--- a/main/configure.ac
+++ b/main/configure.ac
@@ -484,14 +484,9 @@ AC_ARG_ENABLE([epics-tools],
 if test "$enable_epics_tools" = "yes"
 then
 	AX_EPICS
-	AM_CONDITIONAL([EPICS], [true])
-	AM_CONDITIONAL(BUILD_EPICS_TOOLS, [true])
-
-else
-	AM_CONDITIONAL([EPICS], [false])
-	AM_CONDITIONAL(BUILD_EPICS_TOOLS, [false])
 fi
-
+AM_CONDITIONAL(EPICS, test "x$enable_epics_tools" != "x")
+AM_CONDITIONAL(BUILD_EPICS_TOOLS, test "x$enable_epics_tools" != "x")
 
 #   Build the format libraries.
 #

--- a/main/epics/controlpush/Makefile.am
+++ b/main/epics/controlpush/Makefile.am
@@ -64,7 +64,7 @@ cmdline.c: options.ggo
 
 cmdline.h: cmdline.c
 
-EXTRA_DIST = options.ggo  Channels.dat  controlpush.xml
+
 
 
 noinst_PROGRAMS = unittests
@@ -87,3 +87,4 @@ clean-local:
 	rm -f cmdline.c rmcline.h
 
 endif
+EXTRA_DIST = options.ggo  Channels.dat  controlpush.xml


### PR DESCRIPTION
*  Put controlpush's EXTRA_DIST out of the conditional so doc builds won't fail if from a source tarball that was not configured with --enable-epics-tools