### PR TITLE
Rfoxkendo/issue305

### DIFF
--- a/main/mvlc/C785.cpp
+++ b/main/mvlc/C785.cpp
@@ -395,7 +395,15 @@ C785::Initialize(CVMUSB& controller)
   // Set the GEOgraphical address of the module.
 
   uint16_t geo = getIntegerParameter("-geo");
-  controller.vmeWrite16(base+GEO, initamod, geo);
+  // With the MVLC< writing the geo register on a
+  // crate/module with a middle connector buserrs
+  // and we can't have that.  If the user doe4s not specify
+  // geo it is initialized to 0 _and_ in any event, that's
+  // not a legal slot (though it is a legal GEO actually.
+  //
+  if (geo > 0) {
+      controller.vmeWrite16(base+GEO, initamod, geo);
+  }
   controller.vmeWrite16(base+BSet1, initamod, (uint16_t)0x80);
   controller.vmeWrite16(base+BClear1, initamod, (uint16_t)0x80);
 

--- a/main/mvlc/MVLCGenerator.cpp
+++ b/main/mvlc/MVLCGenerator.cpp
@@ -313,7 +313,7 @@ MVLCGenerate::createStopIfNeeded(YAML::Node& node, const char* stackname) {
 
     std::stringstream yamlstream;
     yamlstream << "name: " << stackname << std::endl;
-    yamlstream << "contesnts:\n";
+    yamlstream << "contents:\n";
 
     std::string yamlstring = yamlstream.str();
     YAML::Node yaml = YAML::Load(yamlstring);

--- a/main/mvlc/mvlc_translate.xml
+++ b/main/mvlc/mvlc_translate.xml
@@ -2601,14 +2601,15 @@ adc cget <replaceable>name ?option?</replaceable>
             <command>caenchain</command> module command.
         </para>
         <para>
-            One important difference between the <command>VMUSBReadout</command> and
+            Important ifferences between the <command>VMUSBReadout</command> and
             <command>mvlcgenerate</command> support for these modules is the offline nature of
             <command>mvlcgenerate</command>.  The <command>VMUSBReadout</command> could do module
             type specific initialization by querying the module itself for its type.  This is
             not possible for the <command>mvlcgenerate</command> command.  Therefore the
             additional option <option>-type</option> was added to the configurable options
             to allow you to specify the module type.  See <literal>OPTIONS</literal> below for
-            more information about this.
+            more information about this.  Furthermore, see the cautions in the <option>-geo</option> 
+            documentation.
         </para>
     </refsect1>
     <refsect1>
@@ -2626,17 +2627,20 @@ adc cget <replaceable>name ?option?</replaceable>
             <varlistentry>
                 <term><option>-geo </option> <replaceable>9-bit-value </replaceable></term>
                 <listitem><para>
-                    Specifies the value of the id placed in the id field of the data.  Note that
-                    this value is ignored in modules/backplanes with the CERN P3 extensions.
+                    Specifies the value of the id placed in the id field of the data. 
+                </para><para>
+                     Note that the <option>-geo</option>
+                    option must not be specified in  modules/backplanes with the CERN P3 extensions.
                     Modules/backplanes of that sort will have three connecters (adding a small
                     middle connector to the standard 2 larger VME connectors).  These modules/backplanes
                     get a physical slot number through that extra connector and use that for the
-                    module id.
+                    module id.   Writing to the register that sets the geographical address results in
+                    an initialization error when using <literal>fribdaq-readout</literal>
                 </para><para>
                     Furthermore, Modules that have a middle connector get power through that
                     connector and cannot be used in crates that do not have it without modification.
                     Modules without a middle connector can be used with extended backplanes but
-                    they must have a <option>-geo</option> specified.
+                    they <emphasis>must</emphasis> have a <option>-geo</option> specified.
                 </para></listitem>
             </varlistentry>
             <varlistentry>

--- a/main/mvlc/mvlc_translate.xml
+++ b/main/mvlc/mvlc_translate.xml
@@ -499,7 +499,7 @@ $MVLCROOT/bin/fribdaq-readout <replaceable>options...</replaceable> <replaceable
                 <para>
                     Note that the crate configuration file can also specify the MVLC to use however as that
                     comes from a template file used by <filename>mvlcgenerate</filename> it, normally, should
-                    be overidden by one o fthe options above.
+                    be overidden by one of the options above.
                 </para>
 
                 <variablelist>
@@ -636,17 +636,50 @@ $MVLCROOT/bin/fribdaq-readout <replaceable>options...</replaceable> <replaceable
                             </para>
                         </listitem>
                     </varlistentry>
+                    <varlistentry>
+                            <term><option>-convert-tcl</option></term>
+                            <listitem>
+                                <para>
+                                    The configureation file is taken to be a Tcl DAQ configuration script compatible
+                                    with <command>mvlcgenerate</command> and converted to yaml at the beginning of each run
+                                    before being used as the configuration file.  For this to work, FRIB/NSCLDAQ environment
+                                    variables must have been set up by sourcing a <filename>daqsetup.bash</filename> for
+                                    a version of FRIB/NSCLDAQ that includes <command>mvlcgenerate</command> as that program 
+                                    is used to perform the translation.
+                                </para>
+                                <para>
+                                    If this option is used, <command>mvlcgenerate</command> produces an output file
+                                    in the same directory as the configuration file, prepending the filename with
+                                    a <literal>.</literal> to make it hidden and appending <literal>.yaml</literal>
+                                    to make it clear this is a yaml file.  For example, if the configuration file
+                                    is <filename>/users/ron/configs/daqconfig.tcl</filename>, 
+                                    the generated file will be
+                                    <filename>/users/ron/configs/.daqconfig.tcl.yaml</filename>.
+                                </para>
+                            </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                            <term><option>--template</option> <replaceable>yaml-template-file</replaceable></term>
+                            <listitem>
+                                <para>
+                                    Supports the use of a custom trigger for <command>mclcgenerate</command> when run
+                                    from <command>fribdaq-readout</command>.  See <link linkend="mvlcgen_man" endterm='mvlcgen_man_title' /> 
+                                    for the requirements of this template.  If not supplied, the system installed tamplate is used which 
+                                    triggers the event stack on on the bottom-most NIM connector and triggers the scaler stack every 2 seconds.
+                                </para>
+                            </listitem>
+                    </varlistentry>
                 </variablelist>
             </refsect1>
             <refsect1>
                 <title>Commands</title>
                 <para>
                     The <filename>fribdaq-readout</filename> is controlled by commands that are accepted on
-                    its stdin.  These commands are complmetely compatible with t
-		    he standard FRIB/NSCLDAQ readout command sets and, like all
-		    FRIB/NSCLDAQ readout command interpreters run inside
-		    an event driven Tcl intpereter making it compatible with
-		    the ReST server and ReadoutShell.
+                    its stdin.  These commands are complmetely compatible with the 
+                    standard FRIB/NSCLDAQ readout command sets and, like all
+                    FRIB/NSCLDAQ readout command interpreters run inside
+                    an event driven Tcl intpereter making it compatible with
+                    the ReST server and ReadoutShell.
                 </para>
 
             </refsect1>


### PR DESCRIPTION
* Fix error in mvlcgenerate spelling of contents
* If user does not specify -geo for adc command configuration don't write the geo register.
*  Document why the previous is required.