### PR TITLE
Issue #396 - CVMUSB.h etc. not installed!!!

### DIFF
--- a/main/usb/vmusb/vmusb/Makefile.am
+++ b/main/usb/vmusb/vmusb/Makefile.am
@@ -1,6 +1,10 @@
 lib_LTLIBRARIES		= libVMUSB.la libVMUSBRemote.la libCVMUSB.la \
 	libCVMUSBReadoutList.la
 
+# Install headers in the vmusb subdir.
+
+includedir=@prefix@/include/vmusb
+
 COMPILATION_FLAGS	= $(USBSWITCHES) -I@top_srcdir@/base/headers @LIBTCLPLUS_CFLAGS@  \
 			-I@top_srcdir@/base/tcpip \
 			-I@top_srcdir@/base/os	\
@@ -22,14 +26,14 @@ libVMUSBRemote_la_SOURCES = CVMUSBReadoutList.cpp \
 
 libVMUSBRemote_la_CPPFLAGS=$(COMPILATION_FLAGS)
 
-
-noinst_HEADERS		= CVMUSB.h   \
+include_HEADERS = CVMUSB.h   \
 	CVMUSBReadoutList.h  \
 	CVMUSBusb.h	\
 	CVMUSBEthernet.h \
 	CVMUSBRemote.h       \
-	CVMUSBFactory.h \
-	CMockVMUSB.h \
+	CVMUSBFactory.h
+
+noinst_HEADERS		=  CMockVMUSB.h \
 	CLoggingReadoutList.h \
 	vme_interface_class.h sis_vmusb_interface.h
 


### PR DESCRIPTION
Install a few headers for the VMUSB controller in
@includdir@/vmusb

This prevents pollution of the main $DAQINC dir.

Resolve Issue #396 
$DAQINC/vmusb has e.g. CVMUSB.h CVMUSBReadoutList.h and the factory and a few other headers.