### PR TITLE
Rfoxkendo/issue422

### DIFF
--- a/main/usb/vmusb/CTheApplication.cpp
+++ b/main/usb/vmusb/CTheApplication.cpp
@@ -212,7 +212,19 @@ int CTheApplication::operator()(int argc, char** argv)
     std::cerr << "Attached VMUSB controller with firmware: " << std::hex << 
       Globals::pUSBController->readFirmwareID() << std::dec << std::endl;
 
-    
+    // If the idle busy workaround is enabled, then set the O1 to true as it used to be 
+    // at power up.
+
+#ifdef VMUSB_IDLE_BUSY_WORKAROUND
+    uint32_t defaultDevSelect = Globals::deviceSelectorValue;
+
+    // We need to mask out the busy, and set the O1 source to end of event, inverted.
+
+    defaultDevSelect &= ~CVMUSB::DeviceSourceRegister::nimO1Busy;
+    defaultDevSelect |= CVMUSB::DeviceSourceRegister::nimO1EndOfEvent | 
+      CVMUSB::DeviceSourceRegister::nimO1Invert;
+    Globals::pUSBController->writeDeviceSource(defaultDevSelect); // O1 is now asserted.
+#endif
 
     // Set default configuration file names and then override with the ones supplied on
     // the command line (if any).

--- a/main/usb/vmusb/Globals.cpp
+++ b/main/usb/vmusb/Globals.cpp
@@ -15,6 +15,7 @@
 */
 #include <string>
 #include <tcl.h>
+#include <CVMUSB.h>
 
 
 
@@ -41,4 +42,9 @@ namespace Globals {
   Tcl_ThreadId           mainThreadId = 0;
   CTCLInterpreter*       pMainInterpreter = 0;
   CTheApplication*   pApplication;
-};
+  // Issue #422 device source register to restore.
+  uint32_t           deviceSelectorValue  =CVMUSB::DeviceSourceRegister::nimO1Busy       |
+			    CVMUSB::DeviceSourceRegister::nimO2VMEAS      |
+			    CVMUSB::DeviceSourceRegister::dggADisabled    |
+			    CVMUSB::DeviceSourceRegister::dggBDisabled;      // Default value.
+}

--- a/main/usb/vmusb/Globals.h
+++ b/main/usb/vmusb/Globals.h
@@ -63,6 +63,7 @@ namespace Globals {
   extern Tcl_ThreadId           mainThreadId;
   extern CTCLInterpreter*       pMainInterpreter;
   extern CTheApplication* pApplication;
+  extern uint32_t         deviceSelectorValue; // for issue #422
 };
 
 #endif

--- a/main/usb/vmusb/core/CAcquisitionThread.cpp
+++ b/main/usb/vmusb/core/CAcquisitionThread.cpp
@@ -556,7 +556,8 @@ CAcquisitionThread::startDaq()
 
     // Issue #422 - trigger stack 6 to set the output source selection register properly.
 #ifdef VMUSB_IDLE_BUSY_WORKAROUND
-  m_pVme->writeActionRegister(CVMUSB::ActionRegister::triggerL6);
+  m_pVme->writeActionRegister(CVMUSB::ActionRegister::triggerL6 
+      | CVMUSB::ActionRegister::startDAQ);   // Need to keep DAQ going.
   pApp->logProgress("Workaround stack triggered to set device source register and reset scalers");
 #endif
   pApp->logStateChangeStatus("VMUSB is now in autonomous (data taking) mode");

--- a/main/usb/vmusb/core/CAcquisitionThread.cpp
+++ b/main/usb/vmusb/core/CAcquisitionThread.cpp
@@ -536,7 +536,29 @@ CAcquisitionThread::startDaq()
   }
   // Start the VMUSB in data taking mode:
 
+  // Issue #422 - We need to load stack 6 with instructions to set the device source register and
+  // reset the scalerse.
+
+#ifdef VMUSB_IDLE_BUSY_WORKAROUND
+  CVMUSBReadoutList workaroundList;  
+  workaroundList.addRegisterWrite(
+    CVMUSB::DEVSrcRegister, 
+    Globals::deviceSelectorValue | 
+    CVMUSB::DeviceSourceRegister::scalerAReset | 
+    CVMUSB::DeviceSourceRegister::scalerBReset
+  );                                                   // Set the register and reset the scalers.
+  workaroundList.addRegisterWrite(CVMUSB::DEVSrcRegister, Globals::deviceSelectorValue); //release the scaler reset.
+  m_pVme->loadList(6, workaroundList, CStack::getOffset());
+  pApp->logProgress("Workaround stack loaded to set device source register and reset scalers");
+#endif
+
   VMusbToAutonomous();
+
+    // Issue #422 - trigger stack 6 to set the output source selection register properly.
+#ifdef VMUSB_IDLE_BUSY_WORKAROUND
+  m_pVme->writeActionRegister(CVMUSB::ActionRegister::triggerL6);
+  pApp->logProgress("Workaround stack triggered to set device source register and reset scalers");
+#endif
   pApp->logStateChangeStatus("VMUSB is now in autonomous (data taking) mode");
 
 }

--- a/main/usb/vmusb/daqconfig/CStack.cpp
+++ b/main/usb/vmusb/daqconfig/CStack.cpp
@@ -21,6 +21,7 @@
 #include <CVMUSB.h>
 #include <CVMUSBReadoutList.h>
 #include <CConfiguration.h>
+#include <Globals.h>
 #include <assert.h>
 #include <tcl.h>
 #include <Globals.h>
@@ -327,7 +328,7 @@ CStack::onEndRun(CVMUSB& controller)
   // end of event should always be false when  idle so 
   // its inverse is asserted.
 
-  uint32_t currentSelection = controller.readDeviceSource();
+  uint32_t currentSelection = Globals::deviceSelectorValue;     // What the user asked for
   if ((currentSelection & 0x7) == CVMUSB::DeviceSourceRegister::nimO1Busy) {
     bool inverted = (currentSelection & CVMUSB::DeviceSourceRegister::nimO1Invert) != 0;
 

--- a/main/usb/vmusb/daqconfig/CVMUSBControl.cpp
+++ b/main/usb/vmusb/daqconfig/CVMUSBControl.cpp
@@ -28,6 +28,7 @@
 #include <iomanip>
 #include <sstream>
 #include <CErrnoException.h>
+#include <Globals.h>
 
 
 /*------------------------------------------------------------------------------
@@ -308,14 +309,19 @@ CVMUSBControl::Initialize(CVMUSB& controller)
 
 
   // Setup and clear:
+#ifdef VMUSB_IDLE_BUSY_WORKAROUND  
+
+  Globals::deviceSelectorValue = devSource;  // Issue #422 save the value for later.
   
-  controller.writeDeviceSource(devSource 
-    | CVMUSB::DeviceSourceRegister::scalerAReset
+  #else 
+    controller.writeDeviceSource(devSource 
+    | CVMUSB::DeviceSourceRegister::scalerAReset   // Write the dev soure register.
     | CVMUSB::DeviceSourceRegister::scalerBReset);
 
   // Reassert setup without the clear:
 
-  controller.writeDeviceSource(devSource);
+  controller.writeDeviceSource(devSource);  
+  #endif
 
   // Compute and set the DGGA width/fine delay register.
   

--- a/main/usb/vmusb/daqconfig/TestRunner.cpp
+++ b/main/usb/vmusb/daqconfig/TestRunner.cpp
@@ -5,6 +5,7 @@
 #include <TCLInterpreter.h>
 #include <TCLObject.h>
 #include <stdexcept>
+#include <CVMUSB.h>
 
 
 using namespace std;
@@ -62,3 +63,11 @@ getConfigVal(CTCLInterpreter& interp, const char* option, std::string configStri
   throw std::runtime_error("No such key");
 }
 
+// Need this to satisfy #issue #422 which references this.
+
+namespace Globals {
+  uint32_t           deviceSelectorValue  =CVMUSB::DeviceSourceRegister::nimO1Busy       |
+			    CVMUSB::DeviceSourceRegister::nimO2VMEAS      |
+			    CVMUSB::DeviceSourceRegister::dggADisabled    |
+			    CVMUSB::DeviceSourceRegister::dggBDisabled;      // Default value.
+}


### PR DESCRIPTION
Resolve issue #422  Improve the VMUSB Busy work around.. Specifically, if O1 is intended to be the BUSY, don't restore that until the VMUSB is in autonomous mode.  

Note that this eats up stack 6 because this is accomplished by loading stack 6 with the instructions needed and then software triggering it after the VMUSB is set into autonomous mode.