### PR TITLE
S800triggerdebug

### DIFF
--- a/main/usb/vmusb/ctlconfig/sets800triggerrun.cpp
+++ b/main/usb/vmusb/ctlconfig/sets800triggerrun.cpp
@@ -105,7 +105,7 @@ createReadoutList(CVMUSBReadoutList& list, int argc, char** argv) {
     
     // Run Number seems to be 32 bits(?).
     list.addWrite32(regs.runNumberLowBits(), CVMUSBReadoutList::a32UserData, run);
-    //?  list.addWrite32(regs.runNumberHighBits(), CVMUSBReadoutList::a32UserData, 0);
+    list.addWrite32(regs.runNumberHighBits(), CVMUSBReadoutList::a32UserData, 0);
 
 }
 

--- a/main/utilities/s800scalers/main.cpp
+++ b/main/utilities/s800scalers/main.cpp
@@ -15,6 +15,8 @@
 static const char* COUNTER_MATCH="*_CNT";
 static const char* FREQUENCY_MATCH="*_FRQ";
 
+static const char* RAW_TRIGGERS="R_RAW";   // Raw triggers.
+static const char* LIVE_TRIGGERS="R_LIVE"; // Live triggers.
 
 // Read the JSON configuration file.
 // throws std::exception derived exception on failures
@@ -149,6 +151,22 @@ int main(int argc, char** argv) {
     }
 
     // Process the counters and write them.
+
+    // The live and raw triggers:
+
+    try {
+        std::set<uint32_t> counters;   // Note that make_register_set accumulates but does not preserve order:
+        make_register_set(counters, root, RAW_TRIGGERS);  // Raw trigger counter.
+        dump_register_set(out, counters); 
+        counters.clear();             // Reset for the live triggers.
+        make_register_set(counters, root, LIVE_TRIGGERS); // live trigger counter.
+        dump_register_set(out, counters);
+
+    }
+    catch (std::exception& e) {
+        std::cerr << "Failed to process the trigger counters: " << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
 
     try {    
         std::set<uint32_t> counters;


### PR DESCRIPTION
*  Write both halves of the run number register in the run number writer.
*  Have the scaler readout file generator read the raw and live counters (Rates?).
NOTE: Scalers are not reset after read.