### PR TITLE
Deprecate some old constants, make sure QtScope baseline display work…

### DIFF
--- a/main/ddas/config_pixie16api.h.in
+++ b/main/ddas/config_pixie16api.h.in
@@ -18,25 +18,9 @@
 #endif
 
 /*
-   More deprecated constants used by QtScope (for the time being):
-*/
-
-#ifndef MAX_HISTOGRAM_LENGTH
-#define MAX_HISTOGRAM_LENGTH 32768
-#endif
-
-#ifndef MAX_ADC_TRACE_LEN
-#define MAX_ADC_TRACE_LEN 8192
-#endif
-
-#ifndef MAX_NUM_BASELINES
-#define MAX_NUM_BASELINES 3640
-#endif
-
-/*
    Readout programs need this to decide when to start reading
 */
 
 #ifndef EXTFIFO_READ_THRESH
-#define EXTFIFO_READ_THRESH 1024
+#define EXTFIFO_READ_THRESH 10240
 #endif

--- a/main/ddas/qtscope/CPixieRunUtilities.cpp
+++ b/main/ddas/qtscope/CPixieRunUtilities.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -23,8 +24,8 @@
  * responsible for managing it.
  */
 CPixieRunUtilities::CPixieRunUtilities()
-    : m_histogramLength(0), m_runActive(false), m_useGenerator(false),
-      m_pGenerator(new CDataGenerator) {}
+    : m_histogramLength(0), m_maxBaselines(0), m_runActive(false),
+      m_useGenerator(false), m_pGenerator(new CDataGenerator) {}
 
 /**
  * @details
@@ -38,18 +39,7 @@ CPixieRunUtilities::~CPixieRunUtilities() { delete m_pGenerator; }
 int CPixieRunUtilities::BeginHistogramRun(int module, int nChannels) {
   int retval;
 
-  // Get the length of the histogram data for this module and resize internal
-  // storage:. Assumes all channels on the module have the same histogram
-  // length.
-  unsigned int histLength;
-  retval = PixieGetHistogramLength(module, 0, &histLength);
-  if (retval < 0) {
-    std::stringstream msg;
-    msg << "CPixieRunUtilities::BeginHistogramRun() failed to get "
-        << "histogram length for module " << module;
-    throw CXIAException(msg.str(), "Pixie16GetHistogramLength()", retval);
-  }
-  m_histogramLength = histLength;
+  SetHistogramLength(module);
 
   m_genHistograms.assign(nChannels,
                          std::vector<unsigned int>(m_histogramLength, 0));
@@ -204,16 +194,20 @@ int CPixieRunUtilities::ReadHistogram(int module, int channel) {
  * run flag is set to true when taking a baseline "run."
  *
  * The baseline data itself is stored internally as a histogram of values in
- * [0, MAX_HISTOGRAM_LENGTH). This data structure is reset on begin.
+ * [0, histLength). This data structure is reset on begin.
  */
 int CPixieRunUtilities::BeginBaselineRun(int module, int nChannels) {
   std::cout << "Beginning baseline run in Mod. " << module << std::endl;
 
-  // Reset internal histogram data:
-  m_baselineHistograms.assign(
-      nChannels, std::vector<unsigned int>(MAX_HISTOGRAM_LENGTH, 0));
-  if (m_baseline.size() != MAX_NUM_BASELINES) {
-    m_baseline.resize(MAX_NUM_BASELINES);
+  SetHistogramLength(module);
+  SetMaxBaselines(module);
+
+  // Reset internal histogram data. We assume all channels on the module have
+  // the same maximum baseline length.
+  m_baselineHistograms.assign(nChannels,
+                              std::vector<unsigned int>(m_histogramLength, 0));
+  if (m_baseline.size() != m_histogramLength) {
+    m_baseline.resize(m_histogramLength);
   }
   std::fill(m_baseline.begin(), m_baseline.end(), 0);
 
@@ -260,13 +254,18 @@ int CPixieRunUtilities::ReadBaseline(int module, int channel) {
     // To treat this like a run, make cumulative histogram of read values:
 
     UpdateBaselineHistograms(module);
-
-    // The baseline we want (other channels are also updated):
-    m_baseline = m_baselineHistograms[channel];
+    // Copy the single channel baseline data to a local variable for access via
+    // a getter:
+    std::copy(m_baselineHistograms[channel].begin(),
+              m_baselineHistograms[channel].end(), m_baseline.begin());
   } catch (const CXIAException &e) {
+    std::fill(m_baseline.begin(), m_baseline.end(),
+              0); // Reset baseline data on failure.
     std::cerr << e.ReasonText() << std::endl;
     return -1;
   } catch (const std::runtime_error &e) {
+    std::fill(m_baseline.begin(), m_baseline.end(),
+              0); // Reset baseline data on failure... in this branch
     std::cerr << e.what() << std::endl;
     return -2;
   }
@@ -324,53 +323,6 @@ int CPixieRunUtilities::ReadModuleStats(int module) {
 
 /**
  * @details
- * Update baseline histograms using data read from the module or the data
- * generator. Note that the internal histogram maintained by this class has
- * MAX_HISTOGRAM_LENGTH bins, [), 1 ADC unit/bin. Values outside this range
- * are dropped and not dispayed. This may result in partial or no data being
- * displayed for a baseline run depending on how the baseline looks.
- *
- * @todo (ASC 7/14/23): Handle out of range values better, at least warning
- * the user that something has been dropped.
- */
-void CPixieRunUtilities::UpdateBaselineHistograms(int module) {
-  int retval;
-
-  module_config cfg;
-  PixieGetModuleInfo(module, &cfg);
-
-  for (int i = 0; i < cfg.number_of_channels; i++) {
-    std::vector<double> baselines(MAX_NUM_BASELINES, 0);
-    std::vector<double> timestamps(MAX_NUM_BASELINES, 0);
-    // Allocate data structure for baselines and grab them or use the
-    // data generator to get data for testing:
-    if (m_useGenerator) {
-      retval =
-          m_pGenerator->GetBaselineData(baselines.data(), MAX_NUM_BASELINES);
-    } else {
-      retval = Pixie16ReadSglChanBaselines(baselines.data(), timestamps.data(),
-                                           MAX_NUM_BASELINES, module, i);
-    }
-
-    if (retval < 0) {
-      std::stringstream msg;
-      msg << "CPixieRunUtilities::UpdateBaselineHistograms() failed"
-          << " to read baseline from module " << module << " channel " << i;
-      throw CXIAException(msg.str(), "Pixie16ReadSglChanBaselines", retval);
-    }
-
-    // If we have the baseline, update its histogram for valid values:
-    for (const auto &ele : baselines) {
-      int bin = static_cast<int>(ele);
-      if (bin >= 0 && bin < MAX_HISTOGRAM_LENGTH) {
-        m_baselineHistograms[i][bin]++;
-      }
-    }
-  }
-}
-
-/**
- * @details
  * It is assumed that all channels on a module have the same histogram length.
  * Since this function cannot be called until after the system is booted, there
  * is no need to check for that condition here. The caller assumes responsibilty
@@ -393,4 +345,80 @@ int CPixieRunUtilities::GetHistogramLength(int module) {
   }
 
   return static_cast<int>(histLength);
+}
+
+/**
+ * @details
+ * It is assumed that all channels on a module have the same max baseline size.
+ * Since this function cannot be called until after the system is booted, there
+ * is no need to check for that condition here. The caller assumes responsibilty
+ * for making sure the module number is valid.
+ */
+int CPixieRunUtilities::GetMaxBaselines(int module) {
+  unsigned int maxBaselines = 0;
+  try {
+    int retval = PixieGetMaxNumBaselines(module, 0, &maxBaselines);
+    if (retval < 0) {
+      std::stringstream msg;
+      msg << "CPixieRunUtilities::GetMaxBaselines() failed to get max "
+             "baselines for module "
+          << module;
+      throw CXIAException(msg.str(), "PixieGetMaxNumBaselines()", retval);
+    }
+  } catch (const CXIAException &e) {
+    std::cerr << e.ReasonText() << std::endl;
+    return e.ReasonCode();
+  }
+
+  return static_cast<int>(maxBaselines);
+}
+
+///
+// Private functions
+//
+
+/**
+ * @details
+ * Update baseline histograms using data read from the module or the data
+ * generator. Note that the internal histogram maintained by this class is the
+ * max allowed histogram length for the module type, [0, nbins), 1 ADC unit/bin.
+ * Values outside this range are dropped and not dispayed. This may result in
+ * partial or no data being displayed for a baseline run depending on how the
+ * baseline looks.
+ * @todo (ASC 7/14/23): Handle out of range values better, at least warning
+ * the user that something has been dropped.
+ */
+void CPixieRunUtilities::UpdateBaselineHistograms(int module) {
+  int retval;
+
+  module_config cfg;
+  PixieGetModuleInfo(module, &cfg);
+
+  for (int i = 0; i < cfg.number_of_channels; i++) {
+    std::vector<double> baselines(m_maxBaselines, 0);
+    std::vector<double> timestamps(m_maxBaselines, 0);
+    // Allocate data structure for baselines and grab them or use the
+    // data generator to get data for testing:
+    if (m_useGenerator) {
+      retval = m_pGenerator->GetBaselineData(baselines.data(), m_maxBaselines);
+    } else {
+      retval = Pixie16ReadSglChanBaselines(baselines.data(), timestamps.data(),
+                                           m_maxBaselines, module, i);
+    }
+
+    if (retval < 0) {
+      std::stringstream msg;
+      msg << "CPixieRunUtilities::UpdateBaselineHistograms() failed"
+          << " to read baseline from module " << module << " channel " << i;
+      throw CXIAException(msg.str(), "Pixie16ReadSglChanBaselines", retval);
+    }
+
+    // If we have the baseline, update its histogram for valid values:
+    for (const auto &ele : baselines) {
+      int bin = static_cast<int>(ele);
+      if (bin >= 0 && bin < m_histogramLength) {
+        m_baselineHistograms[i][bin]++;
+      }
+    }
+  }
 }

--- a/main/ddas/qtscope/CPixieRunUtilities.h
+++ b/main/ddas/qtscope/CPixieRunUtilities.h
@@ -34,9 +34,11 @@ private:
   /** Generated run data histograms for all channels. */
   std::vector<std::vector<unsigned int>> m_genHistograms;
   unsigned int m_histogramLength; //!< Length of histogram for current module
-  bool m_runActive;               //!< True when running.
-  bool m_useGenerator;            //!< True to use generator test data.
-  CDataGenerator *m_pGenerator;   //!< Generator for synthetic data.
+  unsigned int
+      m_maxBaselines;  //!< Max number of baselines which can be read out
+  bool m_runActive;    //!< True when running.
+  bool m_useGenerator; //!< True to use generator test data.
+  CDataGenerator *m_pGenerator; //!< Generator for synthetic data.
 
 public:
   /** @brief Constructor. */
@@ -131,6 +133,13 @@ public:
    * @returns The histogram length for the module or XIA error code if failed.
    */
   int GetHistogramLength(int module);
+  /**
+   * @brief Get the maximum number of baselines for a module.
+   * @param module Module number (zero-indexed).
+   * @returns The maximum number of baseline values which can be read out at
+   * once for this module or XIA error code if failed.
+   */
+  int GetMaxBaselines(int module);
 
 private:
   /**
@@ -139,6 +148,27 @@ private:
    * @throw CXIAExeption If the baseline read fails.
    */
   void UpdateBaselineHistograms(int module);
+  /**
+   * @brief Set the histogram length for a module. This is only used for
+   * testing with the generator and should not be used in normal operation.
+   * @param module Module number (zero-indexed).
+   * @note Histogram length is assume to be the same for all channels on a
+   * module. This is a private functon since the histogram length is determined
+   * by the module and should not be set from the outside.
+   */
+  void SetHistogramLength(int module) {
+    m_histogramLength = static_cast<unsigned int>(GetHistogramLength(module));
+  };
+  /**
+   * @brief Set the maximum number of baselines for a module
+   * @param module Module number (zero-indexed)
+   * @note Max number of baselines is assumed to be the same for all channels on
+   * a module. This is a private method since the max number of baselines is
+   * determined by the module and should not be set from the outside.
+   */
+  void SetMaxBaselines(int module) {
+    m_maxBaselines = static_cast<unsigned int>(GetMaxBaselines(module));
+  };
 };
 
 /** @} */
@@ -202,6 +232,12 @@ void CPixieRunUtilities_SetUseGenerator(CPixieRunUtilities *utils, bool mode) {
 /** @brief Wrapper to get histogram length for a single module. */
 int CPixieRunUtilities_GetHistogramLength(CPixieRunUtilities *utils, int mod) {
   return utils->GetHistogramLength(mod);
+}
+/**
+ * @brief Wrapper to get the maximum number of baselines for a single module.
+ */
+int CPixieRunUtilities_GetMaxBaselines(CPixieRunUtilities *utils, int mod) {
+  return utils->GetMaxBaselines(mod);
 }
 
 /** @brief Wrapper for the class constructor. */

--- a/main/ddas/qtscope/Makefile.am
+++ b/main/ddas/qtscope/Makefile.am
@@ -3,28 +3,30 @@ bin_PROGRAMS = qtscope.bin
 lib_LTLIBRARIES = libPixieUtilities.la
 
 qtscope_bin_SOURCES = qtscope.cpp
-qtscope_bin_CXXFLAGS = @PYTHON3_CFLAGS@ 			\
-	@PIXIE_CPPFLAGS@ 					\
+qtscope_bin_CXXFLAGS = \
+	@PYTHON3_CFLAGS@									\
+	@PIXIE_CPPFLAGS@ 									\
 	-DPREFIX=\"@prefix@\"
 qtscope_bin_LDFLAGS = @PYTHON3_LIBS@
 
-libPixieUtilities_la_SOURCES = 					\
+libPixieUtilities_la_SOURCES = \
 	CPixieDSPUtilities.cpp CPixieDSPUtilities.h 		\
 	CPixieRunUtilities.cpp CPixieRunUtilities.h 		\
 	CPixieSystemUtilities.cpp CPixieSystemUtilities.h 	\
 	CPixieTraceUtilities.cpp CPixieTraceUtilities.h 	\
 	CDataGenerator.cpp CDataGenerator.h
-libPixieUtilities_la_CPPFLAGS = 				\
-	-I@top_builddir@/ddas 					\
-	-I@top_srcdir@/ddas/configuration 			\
-	-I@top_srcdir@/ddas/booter 				\
-	-I@top_srcdir@/ddas/exception @LIBTCLPLUS_CFLAGS@ 	\
+libPixieUtilities_la_CPPFLAGS = \
+	-I@top_builddir@/ddas 								\
+	-I@top_srcdir@/ddas/configuration 					\
+	-I@top_srcdir@/ddas/booter 							\
+	-I@top_srcdir@/ddas/exception 						\
+	@LIBTCLPLUS_CFLAGS@ 								\
 	@PIXIE_CPPFLAGS@
 libPixieUtilities_la_LIBADD = \
 	@top_builddir@/ddas/configuration/libConfiguration.la 	\
-        @top_builddir@/ddas/booter/libSystemBooter.la 		\
-	@PIXIE_LDFLAGS@ \
-	@top_builddir@/ddas/exception/libDDASException.la 	\
+    @top_builddir@/ddas/booter/libSystemBooter.la 			\
+	@top_builddir@/ddas/exception/libDDASException.la 		\
+	@PIXIE_LDFLAGS@ 										\
 	@LIBEXCEPTION_LDFLAGS@
 
 FIGURES = timing_diagram.png
@@ -39,11 +41,11 @@ install-exec-hook:
 	$(mkinstalldirs) @prefix@/bin
 	$(INSTALL_PROGRAM) qtscope @prefix@/bin
 
-EXTRA_DIST = acquisition_toolbar.py adc_trace.py analog_signal.py baseline.py cfd.py chan_dsp_gui.py \
-chan_dsp_layout.py chan_dsp_widget.py colors.py converters.py crate_id.py csra.py csrb.py dsp_manager.py \
-dsp_toolbar.py energy_filter.py extensions.py fit_exp_creator.py fit_factory.py fit_function.py \
-fit_gauss_creator.py fit_gauss_p1_creator.py fit_gauss_p2_creator.py fit_panel.py gui.py \
-histogram.py main.py mod_dsp_gui.py mod_dsp_layout.py mult_coincidence.py pixie_utilities.py \
-plot.py plot_toolbar.py qdclen.py run_type.py system_toolbar.py tau.py thread_pool_manager.py \
-timing_control.py trace_analyzer.py trigconfig0.py trigconfigextra.py trigger_filter.py \
+EXTRA_DIST = acquisition_toolbar.py adc_trace.py analog_signal.py baseline.py cfd.py chan_dsp_gui.py 		\
+chan_dsp_layout.py chan_dsp_widget.py colors.py converters.py crate_id.py csra.py csrb.py dsp_manager.py 	\
+dsp_toolbar.py energy_filter.py extensions.py fit_exp_creator.py fit_factory.py fit_function.py 			\
+fit_gauss_creator.py fit_gauss_p1_creator.py fit_gauss_p2_creator.py fit_panel.py gui.py 					\
+histogram.py main.py mod_dsp_gui.py mod_dsp_layout.py mult_coincidence.py pixie_utilities.py 				\
+plot.py plot_toolbar.py qdclen.py run_type.py system_toolbar.py tau.py thread_pool_manager.py 				\
+timing_control.py trace_analyzer.py trigconfig0.py trigconfigextra.py trigger_filter.py 					\
 widget_factory.py xia_constants.py qtscope.dox figures

--- a/main/ddas/qtscope/pixie_utilities.py
+++ b/main/ddas/qtscope/pixie_utilities.py
@@ -596,6 +596,8 @@ class RunUtilities:
         Set ParameterManager offline mode.
     get_histogram_length(module)
         Get the histogram length for a single module.
+    get_max_baselines(module)
+        Get the maximum number of baselines for a single module.
     """
 
     def __init__(self):
@@ -650,6 +652,10 @@ class RunUtilities:
         # Get histogram length
         lib.CPixieRunUtilities_GetHistogramLength.argtypes = [c_void_p, c_int]
         lib.CPixieRunUtilities_GetHistogramLength.restype = c_int
+
+        # Get max baselines
+        lib.CPixieRunUtilities_GetMaxBaselines.argtypes = [c_void_p, c_int]
+        lib.CPixieRunUtilities_GetMaxBaselines.restype = c_int
 
         # Dtor:
         lib.CPixieRunUtilities_delete.argtypes = [POINTER(c_char)]
@@ -863,6 +869,31 @@ class RunUtilities:
             return nbins
         except RuntimeError as e:
             self.logger.exception(f"Failed to read module {module} histogram length")
+            print(e)
+            return -1
+
+    def get_max_baselines(self, module):
+        """Wrapper to get the maximum number of baselines for a single module.
+
+        Parameters
+        ----------
+        module : int
+            Module number.
+
+        Returns
+        -------
+        int
+            Maximum number of baselines or -1 if error.
+        """
+        try:
+            max_baselines = lib.CPixieRunUtilities_GetMaxBaselines(self.obj, module)
+            if max_baselines < 0:
+                raise RuntimeError(
+                    f"Failed to read Mod. {module} maximum baselines with retval {max_baselines}"
+                )
+            return max_baselines
+        except RuntimeError as e:
+            self.logger.exception(f"Failed to read module {module} maximum baselines")
             print(e)
             return -1
 

--- a/main/ddas/readout/CMyTrigger.cpp
+++ b/main/ddas/readout/CMyTrigger.cpp
@@ -21,7 +21,7 @@ const int TRIGGER_TIMEOUT_SECS = 5; //!< Auto-trigger timeout in seconds.
  * 32-bit words that must be in the FIFO for the trigger to fire.
  */
 CMyTrigger::CMyTrigger()
-    : m_retrigger(false), m_fifoThreshold(EXTFIFO_READ_THRESH * 10),
+    : m_retrigger(false), m_fifoThreshold(EXTFIFO_READ_THRESH),
       m_wordsInEachModule(nullptr) {
   const char *pThreshold = getenv("FIFO_THRESHOLD");
   if (pThreshold) {


### PR DESCRIPTION
…s for 32-channel modules (currently not supported by XIA)