### PR TITLE
Rfoxkendo/issue483

### DIFF
--- a/main/docbuild/Makefile.am
+++ b/main/docbuild/Makefile.am
@@ -53,6 +53,7 @@ BOOKDIRS =@top_srcdir@ \
 	@top_srcdir@/daq/format \
 	@top_srcdir@/utilities/manager \
 	@top_srcdir@/utilities/readoutREST \
+	@top_srcdir@/utilities/daqstart \
 	@top_srcdir@/usb \
 	@top_srcdir@/usb/usb1 \
 	@top_srcdir@/usb/vmusb \

--- a/main/utilities/daqstart/Makefile.am
+++ b/main/utilities/daqstart/Makefile.am
@@ -31,11 +31,11 @@ cmdline.c: cmdline.h
 cmdline.h: daqstart.ggo
 	$(GENGETOPT) --unamed-opts <@top_srcdir@/utilities/daqstart/daqstart.ggo
 
-EXTRA_DIST=daqstart.ggo popup.tcl daqstart.xml Makefile.am config.h
+EXTRA_DIST=daqstart.ggo popup.tcl popup.py  daqstart.xml Makefile.am config.h
 
 
 install-exec-local:
-	$(INSTALL_SCRIPT) @srcdir@/popup.tcl $(bindir)/PopUp
+	$(INSTALL_SCRIPT) @srcdir@/popup.py $(bindir)/PopUp
 
 
 check_PROGRAMS = unittests

--- a/main/utilities/daqstart/daqstart.xml
+++ b/main/utilities/daqstart/daqstart.xml
@@ -210,5 +210,88 @@ daqstart <option>options...</option> <replaceable>command </replaceable>
   </refsect1>
 
 </refentry>
+<refentry>
+    <refmeta>
+        <refentrytitle>PopUp</refentrytitle>
+        <manvolnum>1daq</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>PopUp</refname>
+        <refpurpose>Script to make a popup dialog</refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <cmdsynopsis>
+<command>$DAQBIN/PopUp</command>
+<arg>-T | --title=<replaceable>title-string</replaceable></arg>
+<arg>-t | --type=<replaceable>dialog-type</replaceable></arg>
+
+<arg choice='plain'>dialog-text</arg>
+        </cmdsynopsis>
+    </refsynopsisdiv>
+    <refsect1>
+        <title>DESCRIPTION</title>
+        <para>
+            This program allows scripts and programs that are not built around GUIs to 
+            pop up a dialog box to get the user's attention.  In GUi heavy situations,
+            messages written to stderr are easily overlooked and may go unintentionally 
+            ignored.
+        </para>
+        <para>
+            The <parameter>dialog-text</parameter> is displayed in the middle of the popup
+            window.  <option>-t</option> (long option <option>--type</option>) controls the dialog type,
+            which determines the image icon, if any, displayed to the left of the text.
+            Valid values for <option>--type</option>
+            <variablelist>
+                <varlistentry>
+                        <term><literal>about</literal></term>
+                        <listitem>
+                            <para>
+                                No image icon will be displayed in the dialog.
+                            </para>
+                        </listitem>
+                </varlistentry>
+                <varlistentry>
+                        <term><literal>critical</literal></term>
+                        <listitem>
+                            <para>
+                                A red circle with a white X icon will be displayed
+                                 in the dialog.
+                            </para>
+                        </listitem>
+                </varlistentry>
+                <varlistentry>
+                        <term><literal>information</literal></term>
+                        <listitem>
+                            <para>
+                                A blue <literal>i</literal> in a white cartoon dialog bubble will
+                                be displayed in the dialog
+                            </para>
+                        </listitem>
+                </varlistentry>
+                <varlistentry>
+                        <term><literal>question</literal></term>
+                        <listitem>
+                            <para>
+                                A blue question mark in a white cartoon bubble will be displayed in the
+                                dialog.
+                            </para>
+                        </listitem>
+                </varlistentry>
+                <varlistentry>
+                        <term><literal>warning</literal></term>
+                        <listitem>
+                            <para>
+                                A black exclamation point in a yellow triangle will be displayed in the dialog.
+                            </para>
+                        </listitem>
+                </varlistentry>
+            </variablelist>
+        </para>
+        <para>
+            The <option>-T</option> (long option <option>--title</option>) is the title string displayed at the
+            top of the dialog box.
+        </para>
+    </refsect1>
+</refentry>
 
 <!-- /manpage -->

--- a/main/utilities/daqstart/popup.py
+++ b/main/utilities/daqstart/popup.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+#    This software is Copyright by the Board of Trustees of Michigan
+#    State University (c) Copyright 2014, 2026
+#
+#    You may use this software under the terms of the GNU public license
+#    (GPL).  The terms of this license are described at:
+#
+#     http://www.gnu.org/licenses/gpl.txt
+#
+#	     FRIB
+#	     Michigan State University
+#	     East Lansing, MI 48824-1321
+
+
+
+'''
+  This python script replaces the popup.tcl script to provide
+  a program that can be run from inside scripts to make a popup
+  dialog. A few capabilties are added:
+  
+  --type -t  - type of dialog to popup.  This  detrmines the type of qt dialog popped up:
+              it can have any of the following values:
+                about - a program about message
+                critical - a critical error.
+                information - an informationnal message (the default)
+                question    - a questhead message.
+                warning    - a warning message.
+                
+    The return value of the button is lost, as any non-zero return value from the program
+    (the natural way to do this) is interpreted as an error.
+    
+    @todo figure out a way to get the button value back to the caller.
+'''
+
+import argparse
+import sys
+from PyQt5.QtWidgets import QMessageBox, QApplication, QMainWindow
+from PyQt5.Qt import *
+
+#  Command line option definitions:
+
+parser = argparse.ArgumentParser(
+    prog='popup', description='Make a popup dialog', 
+)
+
+parser.add_argument('message', help='The message to display')
+parser.add_argument('-t', 
+        '--type', choices=['about', 'critical', 'information', 'question', 'warning'],
+        default='information',
+        help='Type of dialog to display defaults to "informaton"'
+)
+parser.add_argument('-T', '--title', default='popup',
+                    help='Dialog box title.  Defeaults to "popup"')
+
+command_args = parser.parse_args()
+message      = command_args.message
+title        = command_args.title
+type         = command_args.type
+
+
+# Figure out the type of dialog to produce:
+app = QApplication(sys.argv)
+
+if type == 'about':
+    icon = QMessageBox.NoIcon
+elif type == 'critical':
+    icon = QMessageBox.Critical
+elif type == 'information':
+    icon = QMessageBox.Information
+elif type == 'question':
+    icon = QMessageBox.Question
+elif type == 'warning':
+    icon = QMessageBox.Warning
+else:
+    print(f'Invalid dialog type {type}', file=sys.stderr)    
+    sys.exit(-1)
+    
+win = QMessageBox(icon, title, message, QMessageBox.Ok)
+
+win.exec()
+sys.exit()
+
+


### PR DESCRIPTION
Resolve issue #483 - replace utilities/daqstart/popup.tcl with python script.  Also documented the resulting $DAQBIN/PopUp command.

Note, popup.tcl remains in the source tree, however popup.py is installed in @bindir@ as PopUp an executable script.